### PR TITLE
Put some duck tape to make the project compile again

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -39,6 +39,22 @@ pub enum Block {
     GC(GC),
 }
 
+impl Block {
+    pub fn as_item(&self) -> Option<&Item> {
+        match self {
+            Block::Item(item) => Some(item),
+            _ => None
+        }
+    }
+
+    pub fn as_item_mut(&mut self) -> Option<&mut Item> {
+        match self {
+            Block::Item(item) => Some(item),
+            _ => None
+        }
+    }
+}
+
 pub enum ItemContent {
     Any(Any),
     Binary(Vec<u8>),
@@ -169,7 +185,7 @@ impl ItemContent {
             }
         }
     }
-    pub fn read (update_decoder: updates::decoder::DecoderV1, ref_num: u16, ptr: block::BlockPtr) -> Self {
+    pub fn read (update_decoder: &mut updates::decoder::DecoderV1, ref_num: u16, ptr: block::BlockPtr) -> Self {
         match ref_num {
             1 => { // Content Deleted
                ItemContent::Deleted(update_decoder.read_len())

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -100,7 +100,7 @@ impl BlockStore {
         for i in 0..num_of_state_updates {
             let number_of_structs = update_decoder.rest_decoder.read_var_uint::<u32>() as usize;
             let client = update_decoder.read_client();
-            let clock: u32 = update_decoder.rest_decoder.read_var_uint();
+            let mut clock: u32 = update_decoder.rest_decoder.read_var_uint();
             let structs = store.get_client_structs_list_with_capacity(client, number_of_structs as usize);
             let id = block::ID { client, clock };
             for j in 0..number_of_structs {

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -4,6 +4,7 @@ use lib0::decoding::Decoder;
 use lib0::encoding::Encoder;
 use std::collections::HashMap;
 use std::vec::Vec;
+use crate::block::Block;
 
 impl StateVector {
     pub fn empty() -> Self {

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -6,6 +6,7 @@ use crate::updates::encoder::UpdateEncoder;
 
 use rand::Rng;
 use lib0::decoding::Decoder;
+use crate::block::Block;
 
 const BIT7: u8 = 0b01000000;
 const BIT8: u8 = 0b10000000;
@@ -251,32 +252,42 @@ impl<'a> Store {
                 .write_var_uint(client_structs.integrated_len as u32 - start_pivot);
             update_encoder.rest_encoder.write_var_uint(start_clock); // initial clock
             for i in (start_pivot as usize)..(client_structs.integrated_len) {
-                if let Some(item) = client_structs.list[i].as_item() {
-                    let info = if item.origin.is_some() { BIT8 } else { 0 } // is left null
-                        | if item.right_origin.is_some() { BIT7 } else { 0 }; // is right null
-                    update_encoder.write_info(info);
-                    if let Some(origin_id) = item.origin.as_ref() {
-                        update_encoder.write_left_id(origin_id);
-                    }
-                    if let Some(right_origin_id) = item.right_origin.as_ref() {
-                        update_encoder.write_right_id(right_origin_id);
-                    }
-                    if item.origin.is_none() && item.right_origin.is_none() {
-                        match &item.parent {
-                            types::TypePtr::NamedRef(type_name_ref) => {
-                                let type_name = &self.types[*type_name_ref as usize].1;
-                                update_encoder.write_parent_info(true);
-                                update_encoder.write_string(type_name);
-                            }
-                            types::TypePtr::Id(id) => {
-                                update_encoder.write_parent_info(false);
-                                update_encoder.write_left_id(&id.id);
-                            }
-                            types::TypePtr::Named(name) => {
-                                update_encoder.write_parent_info(true);
-                                update_encoder.write_string(name)
+                match &client_structs.list[i] {
+                    Block::Item(item) => {
+                        let info = if item.origin.is_some() { BIT8 } else { 0 } // is left null
+                            | if item.right_origin.is_some() { BIT7 } else { 0 }; // is right null
+                        update_encoder.write_info(info);
+                        if let Some(origin_id) = item.origin.as_ref() {
+                            update_encoder.write_left_id(origin_id);
+                        }
+                        if let Some(right_origin_id) = item.right_origin.as_ref() {
+                            update_encoder.write_right_id(right_origin_id);
+                        }
+                        if item.origin.is_none() && item.right_origin.is_none() {
+                            match &item.parent {
+                                types::TypePtr::NamedRef(type_name_ref) => {
+                                    let type_name = &self.types[*type_name_ref as usize].1;
+                                    update_encoder.write_parent_info(true);
+                                    update_encoder.write_string(type_name);
+                                }
+                                types::TypePtr::Id(id) => {
+                                    update_encoder.write_parent_info(false);
+                                    update_encoder.write_left_id(&id.id);
+                                }
+                                types::TypePtr::Named(name) => {
+                                    update_encoder.write_parent_info(true);
+                                    update_encoder.write_string(name)
+                                }
                             }
                         }
+                    },
+                    Block::Skip(skip) => {
+                        update_encoder.write_info(10);
+                        update_encoder.write_len(skip.len);
+                    },
+                    Block::GC(gc) => {
+                        update_encoder.write_info(0);
+                        update_encoder.write_len(gc.len);
                     }
                 }
             }

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -143,8 +143,7 @@ impl<'a> Store {
             client: self.client_id,
             clock: self.get_local_state(),
         };
-        let local_block_list = self.blocks.get_client_structs_list(self.client_id);
-        let pivot = local_block_list.integrated_len as u32;
+        let pivot = self.blocks.get_client_structs_list(self.client_id).integrated_len as u32;
         let item = block::Item {
             id,
             content,
@@ -157,6 +156,7 @@ impl<'a> Store {
             parent_sub: None,
         };
         item.integrate(self, pivot as u32);
+        let local_block_list = self.blocks.get_client_structs_list(self.client_id);
         local_block_list.list.push(block::Block::Item(item));
         local_block_list.integrated_len += 1;
     }

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -115,9 +115,9 @@ pub struct ClientBlockList {
     pub integrated_len: usize,
 }
 
-
 pub struct BlockStore {
     pub clients: HashMap<u64, ClientBlockList, BuildHasherDefault<ClientHasher>>,
+    pub local_block_list: ClientBlockList,
 }
 
 pub struct Store {

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -23,7 +23,7 @@ impl Store {
       }
   }
 
-  pub fn init_type_from_ptr<'a>(&'a mut self, ptr: &types::TypePtr) -> Option<&'a types::Inner> {
+  pub fn init_type_from_ptr(&mut self, ptr: &types::TypePtr) -> Option<&types::Inner> {
     match ptr {
         types::TypePtr::Named(name) => {
           let id = self.init_type_ref(name);
@@ -38,6 +38,15 @@ impl Store {
         }
     }
   }
+
+  pub fn get_type_from_ptr(&self, ptr: &types::TypePtr) -> Option<&types::Inner> {
+      todo!()
+  }
+
+  pub fn get_type_from_ptr_mut(&mut self, ptr: &types::TypePtr) -> Option<&mut types::Inner> {
+      todo!()
+  }
+
   pub fn get_type_ref(&self, string: &str) -> Option<u32> {
     self.type_refs.get(string).map(|r| *r)
   }

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -27,7 +27,7 @@ impl Text {
         tr.store.get_type(&self.ptr).and_then(|inner| {
             if pos == 0 {
                 Some(block::ItemPosition {
-                    parent: inner.ptr,
+                    parent: inner.ptr.clone(),
                     after: None,
                 })
             } else {


### PR DESCRIPTION
In general I've seen that a lot of encoding/decoding logic here is inlined into calling methods. I think we could optimize it into a kind of `Encode`/`Decode` traits and just implement them for necessary cases eg.:

```rust
trait Encode {
  fn encode(&self, encoder: &mut Encoder);
}

trait Decode {
  fn decode(decoder: &mut Decoder) -> Result<Self>;
}

impl Encode for Item { ... }
impl Decode for Item { ... }
```

This is very popular pattern, most commonly known in [serde](https://serde.rs/), which is the facto standard for serialization/deserialization in Rust ecosystem. Re. performance, it's also pretty fast: Rust resolves correct function calls at compile time.