### PR TITLE
Implement find_pivot and IdSet

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -17,7 +17,7 @@ const BLOCK_ITEM_ANY_REF_NUMBER: u8 = 8;
 const BLOCK_ITEM_DOC_REF_NUMBER: u8 = 9;
 const BLOCK_SKIP_REF_NUMBER: u8 = 10;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
 pub struct ID {
     pub client: u64,
     pub clock: u32,
@@ -32,7 +32,7 @@ impl ID {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
 pub struct BlockPtr {
     pub id: ID,
     pub pivot: u32,
@@ -127,6 +127,7 @@ impl Block {
             }
         }
     }
+
     pub fn len (&self) -> u32 {
         match self {
             Block::Item(item) => {
@@ -138,6 +139,14 @@ impl Block {
             Block::GC(gc) => {
                 gc.len
             }
+        }
+    }
+
+    pub fn clock_end(&self) -> u32 {
+        match self {
+            Block::Item(item) => item.id.clock + item.content.len(),
+            Block::Skip(skip) => skip.id.clock + skip.len,
+            Block::GC(gc) => gc.id.clock + gc.len,
         }
     }
 }
@@ -241,6 +250,7 @@ impl Item {
             }
         }
     }
+
     pub fn len (&self) -> u32 {
         self.content.len()
     }

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -56,6 +56,14 @@ impl Block {
         }
     }
 
+    pub fn is_deleted(&self) -> bool {
+        match self {
+            Block::Item(item) => item.deleted,
+            Block::Skip(_) => false,
+            Block::GC(_) => false,
+        }
+    }
+
     pub fn encode(&self, store: &Store, encoder: &mut EncoderV1) {
         match self {
             Block::Item(item) => {

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -39,6 +39,22 @@ pub enum Block {
     GC(GC),
 }
 
+impl Block {
+    pub fn as_item(&self) -> Option<&Item> {
+        match self {
+            Block::Item(item) => Some(item),
+            _ => None
+        }
+    }
+
+    pub fn as_item_mut(&mut self) -> Option<&mut Item> {
+        match self {
+            Block::Item(item) => Some(item),
+            _ => None
+        }
+    }
+}
+
 pub enum ItemContent {
     Any(Any),
     Binary(Vec<u8>),
@@ -169,7 +185,7 @@ impl ItemContent {
             }
         }
     }
-    pub fn read (update_decoder: updates::decoder::DecoderV1, ref_num: u16, ptr: block::BlockPtr) -> Self {
+    pub fn read (update_decoder: &mut updates::decoder::DecoderV1, ref_num: u16, ptr: block::BlockPtr) -> Self {
         match ref_num {
             1 => { // Content Deleted
                ItemContent::Deleted(update_decoder.read_len())

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -17,7 +17,7 @@ const BLOCK_ITEM_ANY_REF_NUMBER: u8 = 8;
 const BLOCK_ITEM_DOC_REF_NUMBER: u8 = 9;
 const BLOCK_SKIP_REF_NUMBER: u8 = 10;
 
-#[derive(Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ID {
     pub client: u64,
     pub clock: u32,
@@ -32,7 +32,7 @@ impl ID {
     }
 }
 
-#[derive(Copy, Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct BlockPtr {
     pub id: ID,
     pub pivot: u32,
@@ -69,7 +69,7 @@ impl Block {
         match self {
             Block::Item(item) => item.deleted,
             Block::Skip(_) => false,
-            Block::GC(_) => false,
+            Block::GC(_) => true,
         }
     }
 
@@ -260,7 +260,7 @@ impl Item {
         let clock = self.id.clock;
         let other = Item {
             id: ID::new(client, clock + diff),
-            left: Some(BlockPtr::from(self.id)),
+            left: Some(BlockPtr::from(ID::new(client, clock + diff - 1))),
             right: self.right.clone(),
             origin: Some(ID::new(client, clock + diff - 1)),
             right_origin: self.right_origin.clone(),

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -100,7 +100,7 @@ impl BlockStore {
         for i in 0..num_of_state_updates {
             let number_of_structs = update_decoder.rest_decoder.read_var_uint::<u32>() as usize;
             let client = update_decoder.read_client();
-            let clock: u32 = update_decoder.rest_decoder.read_var_uint();
+            let mut clock: u32 = update_decoder.rest_decoder.read_var_uint();
             let structs = store.get_client_structs_list_with_capacity(client, number_of_structs as usize);
             let id = block::ID { client, clock };
             for j in 0..number_of_structs {

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -4,6 +4,7 @@ use lib0::decoding::Decoder;
 use lib0::encoding::Encoder;
 use std::collections::HashMap;
 use std::vec::Vec;
+use crate::block::Block;
 
 impl StateVector {
     pub fn empty() -> Self {

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -162,7 +162,7 @@ impl BlockStore {
                     };
                     let item: block::Item = todo!();
                     structs.list.push(block::Block::Item(item));
-                    clock += 1;
+                    clock += item.len();
 
                 } else {
                     // is a GC

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -4,7 +4,7 @@ use lib0::decoding::Decoder;
 use lib0::encoding::Encoder;
 use std::collections::HashMap;
 use std::vec::Vec;
-use crate::block::Block;
+use crate::block::{Block, ID};
 
 impl StateVector {
     pub fn empty() -> Self {
@@ -74,9 +74,41 @@ impl ClientBlockList {
             item.id().clock + item.len()
         }
     }
-    pub fn find_pivot(&self, clock: u32) -> u32 {
-        panic!("implement findIndexSS");
+    pub fn find_pivot(&self, clock: u32) -> Option<usize> {
+        let mut left = 0;
+        let mut right = self.list.len() - 1;
+        let mut mid = &self.list[right];
+        let mut mid_clock = mid.id().clock;
+        if mid_clock == clock {
+            Some(right)
+        } else {
+            //todo: does it even make sense to pivot the search?
+            // If a good split misses, it might actually increase the time to find the correct item.
+            // Currently, the only advantage is that search with pivoting might find the item on the first try.
+            let mut mid_idx = ((clock / (mid_clock + mid.len() - 1)) * right as u32) as usize;
+            while left <= right {
+                mid = &self.list[mid_idx];
+                mid_clock = mid.id().clock;
+                if mid_clock <= clock {
+                    if clock < mid_clock + mid.len() {
+                        return Some(mid_idx)
+                    }
+                    left = mid_idx + 1;
+                } else {
+                    right = mid_idx -1;
+                }
+                mid_idx = (left + right) / 2;
+            }
+
+            None
+        }
     }
+
+    pub fn find_block(&self, clock: u32) -> Option<&Block> {
+        let idx = self.find_pivot(clock)?;
+        Some(&self.list[idx])
+    }
+
     pub fn find_item_clean_start(&mut self, tr: &mut Transaction, clock_start: u32) {
 
     }
@@ -209,5 +241,10 @@ impl BlockStore {
         self.clients
             .entry(client_id)
             .or_insert_with(|| ClientBlockList::with_capacity(capacity))
+    }
+
+    pub fn find(&self, id: &ID) -> Option<&Block> {
+        let blocks = self.clients.get(&id.client)?;
+        blocks.find_block(id.clock)
     }
 }

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -123,7 +123,6 @@ impl BlockStore {
     pub fn new() -> Self {
         Self {
             clients: HashMap::<u64, ClientBlockList, BuildHasherDefault<ClientHasher>>::default(),
-            local_block_list: ClientBlockList::new(),
         }
     }
     pub fn from (update_decoder: &mut updates::decoder::DecoderV1) -> Self {

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -225,7 +225,7 @@ impl<'a> Store {
                 client_struct_list.integrated_len += 1;
 
                 // struct integration done. Now increase clock
-                clock += 1;
+                clock += item.len();
             }
         }
     }

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -6,6 +6,7 @@ use crate::updates::encoder::UpdateEncoder;
 
 use rand::Rng;
 use lib0::decoding::Decoder;
+use crate::block::Block;
 
 const BIT7: u8 = 0b01000000;
 const BIT8: u8 = 0b10000000;
@@ -251,32 +252,42 @@ impl<'a> Store {
                 .write_var_uint(client_structs.integrated_len as u32 - start_pivot);
             update_encoder.rest_encoder.write_var_uint(start_clock); // initial clock
             for i in (start_pivot as usize)..(client_structs.integrated_len) {
-                if let Some(item) = client_structs.list[i].as_item() {
-                    let info = if item.origin.is_some() { BIT8 } else { 0 } // is left null
-                        | if item.right_origin.is_some() { BIT7 } else { 0 }; // is right null
-                    update_encoder.write_info(info);
-                    if let Some(origin_id) = item.origin.as_ref() {
-                        update_encoder.write_left_id(origin_id);
-                    }
-                    if let Some(right_origin_id) = item.right_origin.as_ref() {
-                        update_encoder.write_right_id(right_origin_id);
-                    }
-                    if item.origin.is_none() && item.right_origin.is_none() {
-                        match &item.parent {
-                            types::TypePtr::NamedRef(type_name_ref) => {
-                                let type_name = &self.types[*type_name_ref as usize].1;
-                                update_encoder.write_parent_info(true);
-                                update_encoder.write_string(type_name);
-                            }
-                            types::TypePtr::Id(id) => {
-                                update_encoder.write_parent_info(false);
-                                update_encoder.write_left_id(&id.id);
-                            }
-                            types::TypePtr::Named(name) => {
-                                update_encoder.write_parent_info(true);
-                                update_encoder.write_string(name)
+                match &client_structs.list[i] {
+                    Block::Item(item) => {
+                        let info = if item.origin.is_some() { BIT8 } else { 0 } // is left null
+                            | if item.right_origin.is_some() { BIT7 } else { 0 }; // is right null
+                        update_encoder.write_info(info);
+                        if let Some(origin_id) = item.origin.as_ref() {
+                            update_encoder.write_left_id(origin_id);
+                        }
+                        if let Some(right_origin_id) = item.right_origin.as_ref() {
+                            update_encoder.write_right_id(right_origin_id);
+                        }
+                        if item.origin.is_none() && item.right_origin.is_none() {
+                            match &item.parent {
+                                types::TypePtr::NamedRef(type_name_ref) => {
+                                    let type_name = &self.types[*type_name_ref as usize].1;
+                                    update_encoder.write_parent_info(true);
+                                    update_encoder.write_string(type_name);
+                                }
+                                types::TypePtr::Id(id) => {
+                                    update_encoder.write_parent_info(false);
+                                    update_encoder.write_left_id(&id.id);
+                                }
+                                types::TypePtr::Named(name) => {
+                                    update_encoder.write_parent_info(true);
+                                    update_encoder.write_string(name)
+                                }
                             }
                         }
+                    },
+                    Block::Skip(skip) => {
+                        update_encoder.write_info(10);
+                        update_encoder.write_len(skip.len);
+                    },
+                    Block::GC(gc) => {
+                        update_encoder.write_info(0);
+                        update_encoder.write_len(gc.len);
                     }
                 }
             }

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -143,8 +143,7 @@ impl<'a> Store {
             client: self.client_id,
             clock: self.get_local_state(),
         };
-        let local_block_list = self.blocks.get_client_structs_list(self.client_id);
-        let pivot = local_block_list.integrated_len as u32;
+        let pivot = self.blocks.get_client_structs_list(self.client_id).integrated_len as u32;
         let item = block::Item {
             id,
             content,
@@ -157,6 +156,7 @@ impl<'a> Store {
             parent_sub: None,
         };
         item.integrate(self, pivot as u32);
+        let local_block_list = self.blocks.get_client_structs_list(self.client_id);
         local_block_list.list.push(block::Block::Item(item));
         local_block_list.integrated_len += 1;
     }

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -225,7 +225,7 @@ impl<'a> Store {
                 client_struct_list.integrated_len += 1;
 
                 // struct integration done. Now increase clock
-                clock += item.len();
+                clock += 1;
             }
         }
     }

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -5,9 +5,9 @@ use crate::updates::encoder::{EncoderV1, UpdateEncoder, DSEncoder};
 use crate::updates::decoder::{DecoderV1, UpdateDecoder, DSDecoder};
 
 #[derive(Default, Copy, Clone)]
-struct IdRange {
-    clock: u32,
-    len: u32
+pub(crate) struct IdRange {
+    pub clock: u32,
+    pub len: u32
 }
 
 impl IdRange {
@@ -45,6 +45,8 @@ pub struct IdSet {
     clients: HashMap::<u64, Vec<IdRange>, BuildHasherDefault<ClientHasher>>,
 }
 
+pub(crate) type Iter<'a> = std::collections::hash_map::Iter<'a, u64, Vec<IdRange>>;
+
 impl IdSet {
     pub fn new () -> Self {
         Self::default()
@@ -79,6 +81,10 @@ impl IdSet {
             }
         }
         set
+    }
+
+    pub(crate) fn iter(&self) -> Iter<'_> {
+        self.clients.iter()
     }
 
     pub fn apply_ranges<F>(&self, transaction: &mut Transaction, f: &F) where F: Fn(&Block) -> () {

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -81,8 +81,15 @@ impl IdSet {
         set
     }
 
-    pub fn iterate<F>(&self, transaction: &mut Transaction, f: F) where F: Fn(&Block) -> () {
-        todo!()
+    pub fn apply_ranges<F>(&self, transaction: &mut Transaction, f: &F) where F: Fn(&Block) -> () {
+        // equivalent of JS: Y.iterateDeletedStructs
+        for (client, ranges) in self.clients.iter() {
+            if transaction.store.blocks.clients.contains_key(client) {
+                for range in ranges.iter() {
+                    transaction.iterate_structs(client, range.clock, range.len, f);
+                }
+            }
+        }
     }
 
     fn find_pivot(block: &[IdRange], clock: u32) -> Option<usize> {

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -64,7 +64,7 @@ impl IdSet {
                     let mut len = block.len();
                     if i + 1 < blocks.list.len() {
                         let mut next = &blocks.list[i+1];
-                        while i + 1 < blocks.list.len() && next.id().clock == clock + len && next.is_deleted() {
+                        while i + 1 < blocks.list.len() && next.is_deleted() {
                             len += next.len();
                             i += 1;
                             next = &blocks.list[i+1];

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -1,13 +1,45 @@
 
 use crate::*;
-use crate::block::Block;
+use crate::block::{Block, ID};
+use crate::updates::encoder::{EncoderV1, UpdateEncoder, DSEncoder};
+use crate::updates::decoder::{DecoderV1, UpdateDecoder, DSDecoder};
 
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 struct IdRange {
     clock: u32,
     len: u32
 }
 
+impl IdRange {
+    pub fn new(clock: u32, len: u32) -> Self {
+        IdRange {
+            clock,
+            len,
+        }
+    }
+
+    pub fn encode(&self, encoder: &mut EncoderV1) {
+        encoder.write_ds_clock(self.clock);
+        encoder.write_ds_len(self.len);
+    }
+
+    pub fn decode(decoder: &mut DecoderV1) -> Self {
+        let clock = decoder.read_ds_clock();
+        let len = decoder.read_ds_len();
+        IdRange {
+            clock,
+            len,
+        }
+    }
+}
+
+/// DeleteSet is a temporary object that is created when needed.
+/// - When created in a transaction, it must only be accessed after sorting and merging.
+///   - This DeleteSet is sent to other clients.
+/// - We do not create a DeleteSet when we send a sync message. The DeleteSet message is created
+///   directly from StructStore.
+/// - We read a DeleteSet as a apart of sync/update message. In this case the DeleteSet is already
+///   sorted and merged.
 #[derive(Default)]
 pub struct IdSet {
     clients: HashMap::<u64, Vec<IdRange>, BuildHasherDefault<ClientHasher>>,
@@ -17,7 +49,139 @@ impl IdSet {
     pub fn new () -> Self {
         Self::default()
     }
-    pub fn iterate_blocks (&self, tr: &mut Transaction, f: fn(Block)) {
 
+    pub fn from(store: &BlockStore) -> Self {
+        let mut set = Self::new();
+        for (&client, blocks) in store.clients.iter() {
+            let mut ranges = Vec::with_capacity(blocks.list.len());
+            let mut i = 0;
+            while i < blocks.list.len() {
+                let block = &blocks.list[i];
+                if block.is_deleted() {
+                    let clock = block.id().clock;
+                    let mut len = block.len();
+                    if i + 1 < blocks.list.len() {
+                        let mut next = &blocks.list[i+1];
+                        while i + 1 < blocks.list.len() && next.id().clock == clock + len && next.is_deleted() {
+                            len += next.len();
+                            i += 1;
+                            next = &blocks.list[i+1];
+                        }
+                    }
+                    ranges.push(IdRange::new(clock, len));
+                }
+
+                i += 1;
+            }
+
+            if !ranges.is_empty() {
+                set.clients.insert(client, ranges);
+            }
+        }
+        set
     }
+
+    pub fn iterate<F>(&self, transaction: &mut Transaction, f: F) where F: Fn(&Block) -> () {
+        todo!()
+    }
+
+    fn find_pivot(block: &[IdRange], clock: u32) -> Option<usize> {
+        let mut left = 0;
+        let mut right = block.len() - 1;
+        while left <= right {
+            let mid_idx = (left + right) / 2;
+            let mid = &block[mid_idx];
+            if mid.clock <= clock {
+                if clock < mid.clock + mid.len {
+                    return Some(mid_idx)
+                }
+                left = mid_idx + 1;
+            } else {
+                right = mid_idx - 1;
+            }
+        }
+        None
+    }
+
+    pub fn is_deleted(&self, id: &ID) -> bool {
+        if let Some(block) = self.clients.get(&id.client) {
+            Self::find_pivot(block.as_slice(), id.clock).is_some()
+        } else {
+            false
+        }
+    }
+
+    pub fn sort_and_merge(&mut self) {
+        for block in self.clients.values_mut() {
+            block.sort_by(|a,b| a.clock.cmp(&b.clock));
+            // merge items without filtering or splicing the array
+            // i is the current pointer
+            // j refers to the current insert position for the pointed item
+            // try to merge dels[i] into dels[j-1] or set dels[j]=dels[i]
+            let mut i = 1;
+            let mut j = 1;
+            while i < block.len() {
+                let right = block[i]; // copying 8B element is very cheap
+                let left = &mut block[j-1];
+                if left.clock + left.len >= right.clock {
+                    left.len = left.len.max(right.clock + right.len - left.clock);
+                } else {
+                    if j < i {
+                        block[j] = right.clone();
+                    }
+                    j += 1;
+                }
+                i += 1;
+            }
+
+            if j < block.len() {
+                block.shrink_to(j);
+            }
+        }
+    }
+
+    pub fn insert(&mut self, id: ID, len: u32) {
+        let block = self.clients.entry(id.client).or_default();
+        block.push(IdRange::new(id.clock, len));
+    }
+
+    pub fn encode(&self, encoder: &mut EncoderV1) {
+        encoder.write_len(self.clients.len() as u32);
+        for (&client_id, block) in self.clients.iter() {
+            encoder.reset_ds_cur_val();
+            encoder.write_client(client_id);
+            encoder.write_len(block.len() as u32);
+            for item in block.iter() {
+                item.encode(encoder);
+            }
+        }
+    }
+
+    pub fn decode(decoder: &mut DecoderV1) -> Self {
+        let mut set = Self::new();
+        let client_len = decoder.read_len();
+        let mut i = 0;
+        while i < client_len {
+            decoder.reset_ds_cur_val();
+            let client = decoder.read_client();
+            let block_len = decoder.read_len() as usize;
+            if block_len > 0 {
+                let block = set.clients.entry(client)
+                    .or_insert_with(|| Vec::with_capacity(block_len));
+
+                let mut j = 0;
+                while j < block_len {
+                    block.push(IdRange::decode(decoder));
+                    j += 1;
+                }
+            }
+            i += 1;
+        }
+        set
+    }
+}
+
+#[cfg(test)]
+mod test {
+
 }

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -100,7 +100,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
 use crate::block::ID;
 use crate::id_set::{IdRange, IdSet};
-use crate::types::TypePtr;
+use crate::types::{TypePtr, XorHasher};
 
 pub struct Doc {
     pub client_id: u64,
@@ -115,7 +115,7 @@ pub struct Transaction <'a> {
     pub start_state_vector: StateVector,
     pub merge_blocks: Vec<ID>,
     delete_set: IdSet,
-    changed: HashMap<TypePtr, HashSet<Option<String>>>,
+    changed: HashMap<TypePtr, HashSet<Option<String>>, BuildHasherDefault<XorHasher>>,
 }
 
 pub struct ClientBlockList {

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(shrink_to)]
 //! Yrs "wires" is a high performance CRDT implementation based on the idea of **Shared
 //! Types**. It is a compatible port of the [Yjs](https://github.com/yjs/yjs) CRDT.
 //!
@@ -91,6 +92,7 @@ mod transaction;
 mod updates;
 mod types;
 mod store;
+mod id_set;
 
 use utils::client_hasher::ClientHasher;
 use std::cell::{Cell, RefCell, RefMut};

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -115,9 +115,9 @@ pub struct ClientBlockList {
     pub integrated_len: usize,
 }
 
-
 pub struct BlockStore {
     pub clients: HashMap<u64, ClientBlockList, BuildHasherDefault<ClientHasher>>,
+    pub local_block_list: ClientBlockList,
 }
 
 pub struct Store {

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -119,7 +119,6 @@ pub struct ClientBlockList {
 
 pub struct BlockStore {
     pub clients: HashMap<u64, ClientBlockList, BuildHasherDefault<ClientHasher>>,
-    pub local_block_list: ClientBlockList,
 }
 
 pub struct Store {

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -96,9 +96,11 @@ mod id_set;
 
 use utils::client_hasher::ClientHasher;
 use std::cell::{Cell, RefCell, RefMut};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
 use crate::block::ID;
+use crate::id_set::{IdRange, IdSet};
+use crate::types::TypePtr;
 
 pub struct Doc {
     pub client_id: u64,
@@ -112,6 +114,8 @@ pub struct Transaction <'a> {
     pub store: RefMut<'a, Store>,
     pub start_state_vector: StateVector,
     pub merge_blocks: Vec<ID>,
+    delete_set: IdSet,
+    changed: HashMap<TypePtr, HashSet<Option<String>>>,
 }
 
 pub struct ClientBlockList {

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -98,6 +98,7 @@ use utils::client_hasher::ClientHasher;
 use std::cell::{Cell, RefCell, RefMut};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
+use crate::block::ID;
 
 pub struct Doc {
     pub client_id: u64,
@@ -110,6 +111,7 @@ pub struct StateVector(HashMap<u64, u32, BuildHasherDefault<ClientHasher>>);
 pub struct Transaction <'a> {
     pub store: RefMut<'a, Store>,
     pub start_state_vector: StateVector,
+    pub merge_blocks: Vec<ID>,
 }
 
 pub struct ClientBlockList {

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -23,7 +23,7 @@ impl Store {
       }
   }
 
-  pub fn init_type_from_ptr<'a>(&'a mut self, ptr: &types::TypePtr) -> Option<&'a types::Inner> {
+  pub fn init_type_from_ptr(&mut self, ptr: &types::TypePtr) -> Option<&types::Inner> {
     match ptr {
         types::TypePtr::Named(name) => {
           let id = self.init_type_ref(name);
@@ -38,6 +38,15 @@ impl Store {
         }
     }
   }
+
+  pub fn get_type_from_ptr(&self, ptr: &types::TypePtr) -> Option<&types::Inner> {
+      todo!()
+  }
+
+  pub fn get_type_from_ptr_mut(&mut self, ptr: &types::TypePtr) -> Option<&mut types::Inner> {
+      todo!()
+  }
+
   pub fn get_type_ref(&self, string: &str) -> Option<u32> {
     self.type_refs.get(string).map(|r| *r)
   }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -39,14 +39,6 @@ impl Store {
     }
   }
 
-  pub fn get_type_from_ptr(&self, ptr: &types::TypePtr) -> Option<&types::Inner> {
-      todo!()
-  }
-
-  pub fn get_type_from_ptr_mut(&mut self, ptr: &types::TypePtr) -> Option<&mut types::Inner> {
-      todo!()
-  }
-
   pub fn get_type_ref(&self, string: &str) -> Option<u32> {
     self.type_refs.get(string).map(|r| *r)
   }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -4,7 +4,7 @@ impl Store {
   pub fn get_local_state (&self) -> u32 {
     self.blocks.get_state(self.client_id)
   }
-  pub fn get_type<'a>(&'a self, ptr: &types::TypePtr) -> Option<&'a types::Inner> {
+  pub fn get_type(&self, ptr: &types::TypePtr) -> Option<&types::Inner> {
       match ptr {
           types::TypePtr::NamedRef(name_ref) => {
             self.types.get(*name_ref as usize).map(|t| &t.0)

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -51,23 +51,20 @@ impl <'a> Transaction <'a> {
 
         let clock_end = clock_start + len;
         if let Some(mut index) = self.find_index_clean_start(client, clock_start) {
-            let blocks = &self.store.blocks.clients.get(client).unwrap().list;
-            let mut block = &blocks[index];
-            let mut blocks_len = blocks.len();
+            let mut blocks = self.store.blocks.clients.get(client).unwrap();
+            let mut block = &blocks.list[index];
 
-            while index < blocks_len && block.id().clock < clock_end {
+            while index < blocks.list.len() && block.id().clock < clock_end {
                 if clock_end < block.id().clock + block.len() {
                     self.find_index_clean_start(client, clock_start);
-                    let blocks = &self.store.blocks.clients.get(client).unwrap().list;
-                    blocks_len = blocks.len();
-                    block = &blocks[index];
+                    blocks = self.store.blocks.clients.get(client).unwrap();
+                    block = &blocks.list[index];
                 }
 
                 f(block);
                 index += 1;
 
-                let blocks = &self.store.blocks.clients.get(client).unwrap().list;
-                block = &blocks[index];
+                block = &blocks.list[index];
             }
         }
     }

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -2,6 +2,7 @@ use crate::*;
 
 use updates::encoder::*;
 use std::cell::RefMut;
+use crate::block::{Item, ID, BlockPtr, Block};
 
 impl <'a> Transaction <'a> {
     pub fn new (store: RefMut<'a, Store>) -> Transaction {
@@ -9,6 +10,7 @@ impl <'a> Transaction <'a> {
         Transaction {
             store,
             start_state_vector,
+            merge_blocks: Vec::new(),
         }
     }
     /// Encodes the document state to a binary format.
@@ -38,5 +40,89 @@ impl <'a> Transaction <'a> {
         let mut update_encoder = updates::encoder::EncoderV1::new();
         self.store.write_structs(&mut update_encoder, &self.start_state_vector);
         update_encoder.to_buffer()
+    }
+
+    pub fn iterate_structs<F>(&mut self, client: &u64, clock_start: u32, len: u32, f: &F)
+        where F: Fn(&Block) -> () {
+
+        if len == 0 {
+            return
+        }
+
+        let clock_end = clock_start + len;
+        if let Some(mut index) = self.find_index_clean_start(client, clock_start) {
+            let blocks = &self.store.blocks.clients.get(client).unwrap().list;
+            let mut block = &blocks[index];
+            let mut blocks_len = blocks.len();
+
+            while index < blocks_len && block.id().clock < clock_end {
+                if clock_end < block.id().clock + block.len() {
+                    self.find_index_clean_start(client, clock_start);
+                    let blocks = &self.store.blocks.clients.get(client).unwrap().list;
+                    blocks_len = blocks.len();
+                    block = &blocks[index];
+                }
+
+                f(block);
+                index += 1;
+                
+                let blocks = &self.store.blocks.clients.get(client).unwrap().list;
+                block = &blocks[index];
+            }
+        }
+    }
+
+    pub fn find_index_clean_start(&mut self, client: &u64, clock: u32) -> Option<usize> {
+        let mut id_ptr = None;
+        let mut index = 0;
+
+        {
+            let blocks = self.store.blocks.clients.get_mut(client)?;
+            index = blocks.find_pivot(clock)?;
+            let block = &mut blocks.list[index];
+            if let Some(item) = block.as_item_mut() {
+                if item.id.clock < clock {
+
+                    // if we run over the clock, we need to the split item
+                    let half = item.split(clock - item.id.clock);
+                    if let Some(ptr) = half.right {
+                        id_ptr = Some((ptr.clone(), half.id.clone()))
+                    }
+                    index += 1;
+
+                    self.merge_blocks.push(half.id.clone());
+                    //NOTE: is this right to insert an item right away, or should we always put it
+                    // to transaction.merge_blocks? If we do so, we later may not be able to find it
+                    // by iterating over the blocks alone?
+                    blocks.list.insert(index, Block::Item(half));
+                }
+            }
+        }
+
+        // if we had split an item, it was inserted as a new right. We need to rewrite pointers
+        // of the old right to point into the new_item on its left:
+        //
+        // Before:
+        //  +------+ --> +------+ --> +-------+
+        //  | LEFT |     | ITEM |     | RIGHT |
+        //  +------+ <-- +------+     +-------+
+        //         ^------------------+
+        //
+        // After:
+        //  +------+ --> +------+ --> +-------+
+        //  | LEFT |     | ITEM |     | RIGHT |
+        //  +------+ <-- +------+ <-- +-------+
+        //
+        if let Some((right_ptr, id)) = id_ptr {
+            let right = {
+                let blocks = self.store.blocks.clients.get_mut(&right_ptr.id.client).unwrap();
+                &mut blocks.list[right_ptr.pivot as usize]
+            };
+            if let Some(right_item) = right.as_item_mut() {
+                right_item.left = Some(BlockPtr::from(id))
+            }
+        }
+
+        Some(index)
     }
 }

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -14,7 +14,7 @@ impl <'a> Transaction <'a> {
             start_state_vector,
             merge_blocks: Vec::new(),
             delete_set: IdSet::new(),
-            changed: HashMap::new(),
+            changed: HashMap::with_hasher(BuildHasherDefault::default()),
         }
     }
     /// Encodes the document state to a binary format.

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -65,7 +65,7 @@ impl <'a> Transaction <'a> {
 
                 f(block);
                 index += 1;
-                
+
                 let blocks = &self.store.blocks.clients.get(client).unwrap().list;
                 block = &blocks[index];
             }

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -97,7 +97,7 @@ impl Inner {
   }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialOrd, PartialEq, Ord, Eq, Hash)]
 pub enum TypePtr {
     NamedRef(u32),
     Id(block::BlockPtr),

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -27,7 +27,7 @@ impl Text {
         tr.store.get_type(&self.ptr).and_then(|inner| {
             if pos == 0 {
                 Some(block::ItemPosition {
-                    parent: inner.ptr,
+                    parent: inner.ptr.clone(),
                     after: None,
                 })
             } else {


### PR DESCRIPTION
This PR is build on top of #3. I need a stable compiling branch and it was the one.

Work in progress: This PR introduces implemented `find_pivot` (equivalent of `findIndexSS` from JS API as I presume) and most of the `IdSet` (again as I assume it was supposed to be equivalent of `DeleteSet`).

- IdSet iteration is still missing - it requires adding some extra stuff to `Transaction` which I'm still figuring out.
- I want to introduce tests for implemented functions, but still need to figure that part out. Maybe I'll have to postpone them until a Doc API will be more complete. We'll see.