### PR TITLE
First version of the yrs-python wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
   "yrs",
   "ywasm",
   "lib0",
-  "yrs-api-wrapper"
+  "yrs-api-wrapper",
+  "yrs-python"
 ]

--- a/yrs-python/Cargo.toml
+++ b/yrs-python/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "yrs-python"
+version = "0.1.0"
+authors = ["Pierre-Olivier Simonard <pierre.olivier.simonard@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+name = "yrs"
+crate-type = ["cdylib"]
+
+[dependencies]
+yrs-api-wrapper = {path="../yrs-api-wrapper"}
+pythonize = "0.13.0"
+
+[dependencies.pyo3]
+version = "0.13.2"
+features = ["extension-module"]

--- a/yrs-python/README.md
+++ b/yrs-python/README.md
@@ -1,0 +1,24 @@
+# Yrs-python
+
+
+
+Yrs-python is a Pythong binding to Yrs using Maturin, using pyo3.
+
+Reference : 
+https://docs.rs/crate/maturin/0.10.3
+
+
+### install maturin 
+```
+pip install maturin
+```
+
+
+### Build yrs-python : 
+- Build and install locally as a python module : ``` maturin develop ```
+- Build the wheels and stores them in `target/wheels` : ```maturin build```
+
+
+
+
+

--- a/yrs-python/pyproject.toml
+++ b/yrs-python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["maturin"]
+build-backend = "maturin"

--- a/yrs-python/src/lib.rs
+++ b/yrs-python/src/lib.rs
@@ -1,0 +1,58 @@
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+use pyo3::types::{PyAny };
+use pythonize::{depythonize, pythonize};
+use yrs_api_wrapper;
+
+
+#[pyfunction]
+pub fn merge_updates(updates:Vec<Vec<u8>> ) -> PyResult<Py<PyAny>> {
+ 
+    // Converts a Vec<Vec<u8>>  into a   [&[u8]]
+    let updates_u8 : Vec<&[u8]> = updates.iter().map(|x| &x[..]).collect();
+    
+    let result = yrs_api_wrapper::merge_updates(&updates_u8);
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(pythonize(py, &result)?)
+    
+}
+
+
+#[pyfunction]
+pub fn encode_state_vector_from_update (update: Vec<u8>) -> PyResult<Py<PyAny>> {
+    
+    let result = yrs_api_wrapper::encode_state_vector_from_update(&update);
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(pythonize(py, &result)?)
+}
+
+#[pyfunction]
+pub fn diff_updates (update: Vec<u8>, state_vector: Vec<u8>) -> PyResult<Py<PyAny>> {
+    
+    let result = yrs_api_wrapper::diff_updates(&update, &state_vector);
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(pythonize(py, &result)?)
+
+}
+
+
+#[pymodule(yrs)]
+fn yrs(py: Python, m: &PyModule) -> PyResult<()> {
+    
+    m.add_function(wrap_pyfunction!(merge_updates, m)?)?;
+    m.add_function(wrap_pyfunction!(encode_state_vector_from_update, m)?)?;
+    m.add_function(wrap_pyfunction!(diff_updates, m)?)?;
+
+    Ok(())
+}
+
+
+
+
+

--- a/yrs-python/tests/sample_code.py
+++ b/yrs-python/tests/sample_code.py
@@ -1,0 +1,33 @@
+import yrs
+
+# shows all the functions available in module yrs
+print(dir(yrs))
+
+
+# I used the following JS code to generate a binary buffer :
+
+# const ydoc1 = new Y.Doc()
+# ydoc1.getArray('array_doc1').insert(0, ['example 2, array doc 1, 0th value'])
+# ydoc1.getArray('array_doc1').insert(1, ['example 2, array doc 1, 0th value'])
+# ydoc1.getArray('array2_doc1').insert(0, ['example 2, array 2 doc 1, 0th value'])
+# let currentState1 = Y.encodeStateAsUpdate(ydoc1)
+
+bin_buff1 = [
+    1, 2, 242, 143, 191, 196, 7, 0, 8, 1, 10, 97, 114, 114, 97, 121, 95, 100, 111,
+    99, 49, 2, 119, 33, 101, 120, 97, 109, 112, 108, 101, 32, 50, 44, 32, 97, 114, 114,
+    97, 121, 32, 100, 111, 99, 32, 49, 44, 32, 48, 116, 104, 32, 118, 97, 108, 117, 101,
+    119, 33, 101, 120, 97, 109, 112, 108, 101, 32, 50, 44, 32, 97, 114, 114, 97, 121, 32,
+    100, 111, 99, 32, 49, 44, 32, 48, 116, 104, 32, 118, 97, 108, 117, 101, 8, 1, 11, 97,
+    114, 114, 97, 121, 50, 95, 100, 111, 99, 49, 1, 119, 35, 101, 120, 97, 109, 112, 108,
+    101, 32, 50, 44, 32, 97, 114, 114, 97, 121, 32, 50, 32, 100, 111, 99, 32, 49, 44, 32,
+    48, 116, 104, 32, 118, 97, 108, 117, 101, 0,
+]
+
+
+result = yrs.encode_state_vector_from_update(bin_buff1)
+
+print(result)
+
+# test here the other functions :
+# yrs.merge_updates
+# yrs.diff_updates


### PR DESCRIPTION
First version of the yrs-python wrapper
- it binds to python the methods of `yrs-api-wrapper`
- `yrs-python` relies on `maturin`. Check the `readme` for more details.
- Tested through a sample code that we'll enhance once `yrs-api-wrapper` is completed
