### PR TITLE
Automated publication on PyPI when releasing - using Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Publish on PyPI
+on:
+  release:
+    types: [released]
+jobs:
+  publish_on_pypi:
+    name: Publish on PyPI
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-20.04']
+        python-version: 3.9
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+      
+      - name: install dependancies
+        run: pip install maturin 
+
+      - name: publish on pypi
+        run: cd y-py && maturin publish -u ${{ secrets.PYPI_USERNAME }}
+        env:
+          MATURIN_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Hi Kevin, 

Here is the github actions workflow to publish automatically on PyPI when creating a release.

To make it work, you'll have to set 2 secrets in your repository, by going into Settings >  Secrets > New Repository Secret.
These two keys must be named : `PYPI_USERNAME` and `PYPI_PASSWORD` and hold their respective values.
more details here if necessary : https://docs.github.com/en/actions/reference/encrypted-secrets

Keep me updated once you publish your first release on your own ! 🙂🎉


