### PR TITLE
Unified encoding/decoding

### DIFF
--- a/lib0/benches/lib0_benchmarks.rs
+++ b/lib0/benches/lib0_benchmarks.rs
@@ -12,11 +12,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let mut encoder = Encoder::new();
             for i in 0..(BENCHMARK_SIZE as i64) {
-                encoder.write_var_int(i);
+                encoder.write_ivar(i);
             }
             let mut decoder = Decoder::new(&encoder.buf);
             for i in 0..(BENCHMARK_SIZE as i64) {
-                let num: i64 = decoder.read_var_int();
+                let num: i64 = decoder.read_ivar();
                 assert_eq!(num, i);
             }
         })
@@ -26,11 +26,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let mut encoder = Encoder::new();
             for i in 0..BENCHMARK_SIZE {
-                encoder.write_var_uint(i);
+                encoder.write_uvar(i);
             }
             let mut decoder = Decoder::new(&encoder.buf);
             for i in 0..BENCHMARK_SIZE {
-                let num: u32 = decoder.read_var_uint();
+                let num: u32 = decoder.read_uvar();
                 assert_eq!(num, i);
             }
         })
@@ -40,11 +40,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let mut encoder = Encoder::new();
             for i in 0..BENCHMARK_SIZE {
-                encoder.write_uint32(i);
+                encoder.write_u32(i);
             }
             let mut decoder = Decoder::new(&encoder.buf);
             for i in 0..BENCHMARK_SIZE {
-                let num: u32 = decoder.read_uint32();
+                let num: u32 = decoder.read_u32();
                 assert_eq!(num, i);
             }
         })
@@ -54,11 +54,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let mut encoder = Encoder::new();
             for i in 0..(BENCHMARK_SIZE as u64) {
-                encoder.write_var_uint(i);
+                encoder.write_uvar(i);
             }
             let mut decoder = Decoder::new(&encoder.buf);
             for i in 0..(BENCHMARK_SIZE as u64) {
-                let num: u64 = decoder.read_var_uint();
+                let num: u64 = decoder.read_uvar();
                 assert_eq!(num, i);
             }
         })
@@ -68,11 +68,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             let mut encoder = Encoder::new();
             for i in 0..(BENCHMARK_SIZE as u64) {
-                encoder.write_big_uint64(i)
+                encoder.write_u64(i)
             }
             let mut decoder = Decoder::new(&encoder.buf);
             for i in 0..(BENCHMARK_SIZE as u64) {
-                let num = decoder.read_big_uint64();
+                let num = decoder.read_u64();
                 assert_eq!(num, i);
             }
         })

--- a/lib0/benches/lib0_benchmarks.rs
+++ b/lib0/benches/lib0_benchmarks.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
-use lib0::decoding::Decoder;
-use lib0::encoding::Encoder;
+use lib0::decoding::{Cursor, Read};
+use lib0::encoding::Write;
 
 const BENCHMARK_SIZE: u32 = 100000;
 
@@ -10,11 +10,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("var_int (64 bit)", |b| {
         b.iter(|| {
-            let mut encoder = Encoder::new();
+            let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..(BENCHMARK_SIZE as i64) {
                 encoder.write_ivar(i);
             }
-            let mut decoder = Decoder::new(&encoder.buf);
+            let mut decoder = Cursor::from(&encoder);
             for i in 0..(BENCHMARK_SIZE as i64) {
                 let num: i64 = decoder.read_ivar();
                 assert_eq!(num, i);
@@ -24,11 +24,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("var_uint (32 bit)", |b| {
         b.iter(|| {
-            let mut encoder = Encoder::new();
+            let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..BENCHMARK_SIZE {
                 encoder.write_uvar(i);
             }
-            let mut decoder = Decoder::new(&encoder.buf);
+            let mut decoder = Cursor::from(&encoder);
             for i in 0..BENCHMARK_SIZE {
                 let num: u32 = decoder.read_uvar();
                 assert_eq!(num, i);
@@ -38,11 +38,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("uint32", |b| {
         b.iter(|| {
-            let mut encoder = Encoder::new();
+            let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..BENCHMARK_SIZE {
                 encoder.write_u32(i);
             }
-            let mut decoder = Decoder::new(&encoder.buf);
+            let mut decoder = Cursor::from(&encoder);
             for i in 0..BENCHMARK_SIZE {
                 let num: u32 = decoder.read_u32();
                 assert_eq!(num, i);
@@ -52,11 +52,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("var_uint (64 bit)", |b| {
         b.iter(|| {
-            let mut encoder = Encoder::new();
+            let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..(BENCHMARK_SIZE as u64) {
                 encoder.write_uvar(i);
             }
-            let mut decoder = Decoder::new(&encoder.buf);
+            let mut decoder = Cursor::from(&encoder);
             for i in 0..(BENCHMARK_SIZE as u64) {
                 let num: u64 = decoder.read_uvar();
                 assert_eq!(num, i);
@@ -66,11 +66,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     group.bench_function("uint64", |b| {
         b.iter(|| {
-            let mut encoder = Encoder::new();
+            let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..(BENCHMARK_SIZE as u64) {
                 encoder.write_u64(i)
             }
-            let mut decoder = Decoder::new(&encoder.buf);
+            let mut decoder = Cursor::from(&encoder);
             for i in 0..(BENCHMARK_SIZE as u64) {
                 let num = decoder.read_u64();
                 assert_eq!(num, i);

--- a/lib0/src/any.rs
+++ b/lib0/src/any.rs
@@ -1,3 +1,5 @@
+use crate::decoding::Decoder;
+use crate::encoding::Encoder;
 use std::cmp::PartialEq;
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -13,6 +15,155 @@ pub enum Any {
     Buffer(Box<[u8]>),
     Array(Vec<Any>),
     Map(HashMap<String, Any>),
+}
+
+impl Any {
+    pub fn decode(decoder: &mut Decoder<'_>) -> Self {
+        match decoder.read_u8() {
+            // CASE 127: undefined
+            127 => Any::Undefined,
+            // CASE 126: null
+            126 => Any::Null,
+            // CASE 125: integer
+            125 => Any::Number(decoder.read_ivar() as f64),
+            // CASE 124: float32
+            124 => Any::Number(decoder.read_f32() as f64),
+            // CASE 123: float64
+            123 => Any::Number(decoder.read_f64()),
+            // CASE 122: bigint
+            122 => Any::BigInt(decoder.read_i64()),
+            // CASE 121: boolean (false)
+            121 => Any::Bool(false),
+            // CASE 120: boolean (true)
+            120 => Any::Bool(true),
+            // CASE 119: string
+            119 => Any::String(decoder.read_string().to_owned()),
+            // CASE 118: Map<string,Any>
+            118 => {
+                let len: usize = decoder.read_uvar();
+                let mut map = HashMap::with_capacity(len);
+                for _ in 0..len {
+                    let key = decoder.read_string();
+                    map.insert(key.to_owned(), Any::decode(decoder));
+                }
+                Any::Map(map)
+            }
+            // CASE 117: Array<Any>
+            117 => {
+                let len: usize = decoder.read_uvar();
+                let mut arr = Vec::with_capacity(len);
+                for _ in 0..len {
+                    arr.push(Any::decode(decoder));
+                }
+                Any::Array(arr)
+            }
+            // CASE 116: buffer
+            116 => Any::Buffer(Box::from(decoder.read_var_buffer().to_owned())),
+            _ => {
+                panic!("Unable to read Any content");
+            }
+        }
+    }
+
+    // Encode data with efficient binary format.
+    //
+    // Differences to JSON:
+    // • Transforms data to a binary format (not to a string)
+    // • Encodes undefined, NaN, and ArrayBuffer (these can't be represented in JSON)
+    // • Numbers are efficiently encoded either as a variable length integer, as a
+    //   32 bit float, as a 64 bit float, or as a 64 bit bigint.
+    //
+    // Encoding table:
+    //
+    // | Data Type           | Prefix   | Encoding Method    | Comment |
+    // | ------------------- | -------- | ------------------ | ------- |
+    // | undefined           | 127      |                    | Functions, symbol, and everything that cannot be identified is encoded as undefined |
+    // | null                | 126      |                    | |
+    // | integer             | 125      | writeVarInt        | Only encodes 32 bit signed integers |
+    // | float32             | 124      | writeFloat32       | |
+    // | float64             | 123      | writeFloat64       | |
+    // | bigint              | 122      | writeBigInt64      | |
+    // | boolean (false)     | 121      |                    | True and false are different data types so we save the following byte |
+    // | boolean (true)      | 120      |                    | - 0b01111000 so the last bit determines whether true or false |
+    // | string              | 119      | writeVarString     | |
+    // | object<string,any>  | 118      | custom             | Writes {length} then {length} key-value pairs |
+    // | array<any>          | 117      | custom             | Writes {length} then {length} json values |
+    // | Uint8Array          | 116      | writeVarUint8Array | We use Uint8Array for any kind of binary data |
+    //
+    // Reasons for the decreasing prefix:
+    // We need the first bit for extendability (later we may want to encode the
+    // prefix with writeVarUint). The remaining 7 bits are divided as follows:
+    // [0-30]   the beginning of the data range is used for custom purposes
+    //          (defined by the function that uses this library)
+    // [31-127] the end of the data range is used for data encoding by
+    //          lib0/encoding.js
+    pub fn encode(&self, encoder: &mut Encoder) {
+        match self {
+            Any::Undefined => {
+                // TYPE 127: undefined
+                encoder.write_u8(127)
+            }
+            Any::Null => {
+                // TYPE 126: null
+                encoder.write_u8(126)
+            }
+            Any::Bool(bool) => {
+                // TYPE 120/121: boolean (true/false)
+                encoder.write_u8(if *bool { 120 } else { 121 })
+            }
+            Any::String(str) => {
+                // TYPE 119: String
+                encoder.write_u8(119);
+                encoder.write_string(&str);
+            }
+            Any::Number(num) => {
+                let num_truncated = num.trunc();
+                if num_truncated == *num
+                    && num_truncated <= crate::number::F64_MAX_SAFE_INTEGER
+                    && num_truncated >= crate::number::F64_MIN_SAFE_INTEGER
+                {
+                    // TYPE 125: INTEGER
+                    encoder.write_u8(125);
+                    encoder.write_ivar(num_truncated as i64);
+                } else if ((*num as f32) as f64) == *num {
+                    // TYPE 124: FLOAT32
+                    encoder.write_u8(124);
+                    encoder.write_f32(*num as f32);
+                } else {
+                    // TYPE 123: FLOAT64
+                    encoder.write_u8(123);
+                    encoder.write_f64(*num);
+                }
+            }
+            Any::BigInt(num) => {
+                // TYPE 122: BigInt
+                encoder.write_u8(122);
+                encoder.write_i64(*num);
+            }
+            Any::Array(arr) => {
+                // TYPE 117: Array
+                encoder.write_u8(117);
+                encoder.write_uvar(arr.len() as u64);
+                for el in arr.iter() {
+                    el.encode(encoder);
+                }
+            }
+            Any::Map(map) => {
+                // TYPE 118: Map
+                encoder.write_u8(118);
+                encoder.write_uvar(map.len() as u64);
+                for (key, value) in map {
+                    encoder.write_string(&key);
+                    value.encode(encoder);
+                }
+            }
+            Any::Buffer(buf) => {
+                // TYPE 116: Buffer
+                encoder.write_u8(116);
+                encoder.write_buf(&buf)
+            }
+        }
+    }
 }
 
 impl std::fmt::Display for Any {

--- a/lib0/src/any.rs
+++ b/lib0/src/any.rs
@@ -1,5 +1,5 @@
-use crate::decoding::Decoder;
-use crate::encoding::Encoder;
+use crate::decoding::Read;
+use crate::encoding::Write;
 use std::cmp::PartialEq;
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -18,7 +18,7 @@ pub enum Any {
 }
 
 impl Any {
-    pub fn decode(decoder: &mut Decoder<'_>) -> Self {
+    pub fn decode<R: Read>(decoder: &mut R) -> Self {
         match decoder.read_u8() {
             // CASE 127: undefined
             127 => Any::Undefined,
@@ -58,7 +58,7 @@ impl Any {
                 Any::Array(arr)
             }
             // CASE 116: buffer
-            116 => Any::Buffer(Box::from(decoder.read_var_buffer().to_owned())),
+            116 => Any::Buffer(Box::from(decoder.read_buf().to_owned())),
             _ => {
                 panic!("Unable to read Any content");
             }
@@ -97,7 +97,7 @@ impl Any {
     //          (defined by the function that uses this library)
     // [31-127] the end of the data range is used for data encoding by
     //          lib0/encoding.js
-    pub fn encode(&self, encoder: &mut Encoder) {
+    pub fn encode<W: Write>(&self, encoder: &mut W) {
         match self {
             Any::Undefined => {
                 // TYPE 127: undefined

--- a/lib0/src/decoding.rs
+++ b/lib0/src/decoding.rs
@@ -2,6 +2,7 @@ use crate::any::Any;
 use crate::binary;
 use core::panic;
 use std::collections::HashMap;
+use std::io::Read;
 
 #[derive(Default)]
 pub struct Decoder<'a> {
@@ -13,102 +14,58 @@ impl<'a> Decoder<'a> {
     pub fn new(buf: &'a [u8]) -> Decoder<'a> {
         Decoder { buf, next: 0 }
     }
-    // Read a single byte.
-    pub fn read(&mut self) -> u8 {
+
+    /// Read a single byte.
+    pub fn read_u8(&mut self) -> u8 {
         let b = self.buf[self.next];
         self.next += 1;
         b
     }
-    // Check if there is still content to be read.
-    pub fn has_content(&self) -> bool {
-        self.buf.len() > self.next
-    }
-    // Clone this decoder. This operation is pretty cheap as it only copies references.
-    pub fn clone(&self) -> Decoder<'a> {
-        Decoder {
-            buf: self.buf,
-            next: self.next,
-        }
-    }
-    // Take a slice of the next `len` bytes and advance the position by `len`.
+
+    /// Take a slice of the next `len` bytes and advance the position by `len`.
     pub fn read_buffer(&mut self, len: u32) -> &[u8] {
         let slice = &self.buf[self.next..(self.next + len as usize)];
         self.next += len as usize;
         slice
     }
-    // Read a variable length buffer.
+
+    /// Read a variable length buffer.
     pub fn read_var_buffer(&mut self) -> &[u8] {
-        let len: u32 = self.read_var_uint();
+        let len: u32 = self.read_uvar();
         self.read_buffer(len)
     }
-    // Read a variable length buffer.
-    pub fn peek_var_buffer(&mut self) -> &[u8] {
-        let next = self.next;
-        let len: u32 = self.read_var_uint();
-        let buffer_next = self.next;
-        self.next = next;
-        let slice = &self.buf[buffer_next..(buffer_next + len as usize)];
-        self.next += len as usize;
-        slice
+
+    /// Read 2 bytes as unsigned integer
+    pub fn read_u16(&mut self) -> u16 {
+        self.read_u8() as u16 | ((self.read_u8() as u16) << 8)
     }
-    // Read the remaining bytes as buffer
-    pub fn read_tail_as_buffer(&mut self) -> &[u8] {
-        self.read_buffer((self.buf.len() - self.next) as u32)
+
+    /// Read 4 bytes as unsigned integer
+    pub fn read_u32(&mut self) -> u32 {
+        self.read_u8() as u32
+            | (self.read_u8() as u32) << 8
+            | (self.read_u8() as u32) << 16
+            | (self.read_u8() as u32) << 24
     }
-    // Skip one byte, jump to the next position
-    pub fn skip8(&mut self) {
-        self.next += 1;
+
+    /// Read 4 bytes as unsigned integer in big endian order.
+    /// (most significant byte first)
+    pub fn read_u32_be(&mut self) -> u32 {
+        (self.read_u8() as u32) << 24
+            | (self.read_u8() as u32) << 16
+            | (self.read_u8() as u32) << 8
+            | self.read_u8() as u32
     }
-    // Read one byte as unsigned integer.
-    pub fn read_uint8(&mut self) -> u8 {
-        self.read()
-    }
-    // Read 2 bytes as unsigned integer
-    pub fn read_uint16(&mut self) -> u16 {
-        self.read() as u16 | ((self.read() as u16) << 8)
-    }
-    // Read 4 bytes as unsigned integer
-    pub fn read_uint32(&mut self) -> u32 {
-        self.read() as u32
-            | (self.read() as u32) << 8
-            | (self.read() as u32) << 16
-            | (self.read() as u32) << 24
-    }
-    // Read 4 bytes as unsigned integer in big endian order.
-    // (most significant byte first)
-    pub fn read_uint32_big_endian(&mut self) -> u32 {
-        (self.read() as u32) << 24
-            | (self.read() as u32) << 16
-            | (self.read() as u32) << 8
-            | self.read() as u32
-    }
-    // Look ahead without incrementing the position
-    // to the next byte and read it as unsigned integer.
-    pub fn peek_uint8(&mut self) -> u8 {
-        self.buf[self.next]
-    }
-    // Look ahead without incrementing the position
-    // to the next byte and read it as unsigned integer.
-    pub fn peek_uint16(&mut self) -> u16 {
-        (self.buf[self.next] as u16) | (self.buf[self.next + 1] as u16) << 8
-    }
-    // Look ahead without incrementing the position
-    // to the next byte and read it as unsigned integer.
-    pub fn peek_uint32(&self) -> u32 {
-        self.buf[self.next] as u32
-            | (self.buf[self.next + 1] as u32) << 8
-            | (self.buf[self.next + 2] as u32) << 16
-            | (self.buf[self.next + 3] as u32) << 24
-    }
-    // Read unsigned integer with variable length.
-    // * numbers < 2^7 are stored in one byte
-    // * numbers < 2^14 are stored in two bytes
+
+    /// Read unsigned integer with variable length.
+    /// * numbers < 2^7 are stored in one byte
+    /// * numbers < 2^14 are stored in two bytes
     // @todo currently, only 32 bits supported
-    pub fn read_var_uint<T: crate::number::Uint>(&mut self) -> T {
+    pub fn read_uvar<T: crate::number::Uint>(&mut self) -> T {
         let mut num: T = Default::default();
         let mut len: usize = 0;
         loop {
-            let r = self.read();
+            let r = self.read_u8();
             num.unshift_add(len, r & binary::BITS7);
             len += 7;
             if r < binary::BIT8 {
@@ -119,12 +76,13 @@ impl<'a> Decoder<'a> {
             }
         }
     }
-    // Read signed integer with variable length.
-    // * numbers < 2^7 are stored in one byte
-    // * numbers < 2^14 are stored in two bytes
+
+    /// Read signed integer with variable length.
+    /// * numbers < 2^7 are stored in one byte
+    /// * numbers < 2^14 are stored in two bytes
     // @todo currently, only 32 bits supported
-    pub fn read_var_int(&mut self) -> i64 {
-        let mut r = self.read();
+    pub fn read_ivar(&mut self) -> i64 {
+        let mut r = self.read_u8();
         let mut num = (r & binary::BITS6 as u8) as i64;
         let mut len: u32 = 6;
         let is_negative = r & binary::BIT7 as u8 > 0;
@@ -132,7 +90,7 @@ impl<'a> Decoder<'a> {
             return if is_negative { -num } else { num };
         }
         loop {
-            r = self.read();
+            r = self.read_u8();
             num |= (r as i64 & binary::BITS7 as i64) << len;
             len += 7;
             if r < binary::BIT8 as u8 {
@@ -143,106 +101,63 @@ impl<'a> Decoder<'a> {
             }
         }
     }
-    // Look ahead and read var_uint without incrementing position
+
+    /// Look ahead and read var_uint without incrementing position
     pub fn peek_var_uint(&mut self) -> u64 {
         let pos = self.next;
-        let s = self.read_var_uint();
+        let s = self.read_uvar();
         self.next = pos;
         s
     }
-    // Look ahead and read var_int without incrementing position
+
+    /// Look ahead and read var_int without incrementing position
     pub fn peek_var_int(&mut self) -> i64 {
         let pos = self.next;
-        let s = self.read_var_int();
+        let s = self.read_ivar();
         self.next = pos;
         s
     }
-    // Read string of variable length.
-    // read_var_uint is used to read the length of the string.
-    pub fn read_var_string(&mut self) -> &str {
+
+    /// Read string of variable length.
+    pub fn read_string(&mut self) -> &str {
         let buf = self.read_var_buffer();
         unsafe { std::str::from_utf8_unchecked(buf) }
     }
-    // Look ahead and read var_string without incrementing position
-    pub fn peek_var_string(&mut self) -> &str {
-        let buf = self.peek_var_buffer();
-        unsafe { std::str::from_utf8_unchecked(buf) }
-    }
-    // read buffer of 4 bytes as fixed-length array
+
+    /// Read buffer of 4 bytes as fixed-length array
     pub fn read_buffer_fixed4(&mut self) -> [u8; 4] {
         let buf = self.read_buffer(4);
         let mut res: [u8; 4] = Default::default();
         res.clone_from_slice(buf);
         res
     }
-    // read buffer of 8 bytes as fixed-length array
+
+    /// Read buffer of 8 bytes as fixed-length array
     pub fn read_buffer_fixed8(&mut self) -> [u8; 8] {
         let buf = self.read_buffer(8);
         let mut res: [u8; 8] = Default::default();
         res.clone_from_slice(buf);
         res
     }
-    // Read float32 in big endian order
-    pub fn read_float32(&mut self) -> f32 {
+
+    /// Read float32 in big endian order
+    pub fn read_f32(&mut self) -> f32 {
         f32::from_be_bytes(self.read_buffer_fixed4())
     }
-    // Read float64 in big endian order
+
+    /// Read float64 in big endian order
     // @todo there must be a more elegant way to convert a slice to a fixed-length buffer.
-    pub fn read_float64(&mut self) -> f64 {
+    pub fn read_f64(&mut self) -> f64 {
         f64::from_be_bytes(self.read_buffer_fixed8())
     }
-    // read BigInt64 in big endian order
-    pub fn read_bigint64(&mut self) -> i64 {
+
+    /// Read BigInt64 in big endian order
+    pub fn read_i64(&mut self) -> i64 {
         i64::from_be_bytes(self.read_buffer_fixed8())
     }
-    // read BigUInt64 in big endian order
-    pub fn read_big_uint64(&mut self) -> u64 {
+
+    /// read BigUInt64 in big endian order
+    pub fn read_u64(&mut self) -> u64 {
         u64::from_be_bytes(self.read_buffer_fixed8())
-    }
-    pub fn read_any(&mut self) -> Any {
-        match self.read_uint8() {
-            // CASE 127: undefined
-            127 => Any::Undefined,
-            // CASE 126: null
-            126 => Any::Null,
-            // CASE 125: integer
-            125 => Any::Number(self.read_var_int() as f64),
-            // CASE 124: float32
-            124 => Any::Number(self.read_float32() as f64),
-            // CASE 123: float64
-            123 => Any::Number(self.read_float64()),
-            // CASE 122: bigint
-            122 => Any::BigInt(self.read_bigint64()),
-            // CASE 121: boolean (false)
-            121 => Any::Bool(false),
-            // CASE 120: boolean (true)
-            120 => Any::Bool(true),
-            // CASE 119: string
-            119 => Any::String(self.read_var_string().to_owned()),
-            // CASE 118: Map<string,Any>
-            118 => {
-                let len: usize = self.read_var_uint();
-                let mut map = HashMap::with_capacity(len);
-                for _ in 0..len {
-                    let key = self.read_var_string();
-                    map.insert(key.to_owned(), self.read_any());
-                }
-                Any::Map(map)
-            }
-            // CASE 117: Array<Any>
-            117 => {
-                let len: usize = self.read_var_uint();
-                let mut arr = Vec::with_capacity(len);
-                for _ in 0..len {
-                    arr.push(self.read_any());
-                }
-                Any::Array(arr)
-            }
-            // CASE 116: buffer
-            116 => Any::Buffer(Box::from(self.read_var_buffer().to_owned())),
-            _ => {
-                panic!("Unable to read Any content");
-            }
-        }
     }
 }

--- a/lib0/src/encoding.rs
+++ b/lib0/src/encoding.rs
@@ -10,83 +10,61 @@ impl Encoder {
     pub fn new() -> Encoder {
         Encoder::with_capacity(10000)
     }
+
     pub fn with_capacity(capacity: usize) -> Encoder {
         Encoder {
             buf: Vec::with_capacity(capacity),
         }
     }
-    // Write a single byte to the encoder
-    pub fn write(&mut self, byte: u8) {
+
+    /// Write a single byte to the encoder
+    pub fn write_u8(&mut self, byte: u8) {
         self.buf.push(byte);
     }
-    // Returns the byte-length of the data written to the encoder.
-    pub fn len(&self) -> usize {
-        self.buf.len()
+
+    /// Write an unsigned integer (16bit)
+    pub fn write_u16(&mut self, num: u16) {
+        self.write_u8(num as u8);
+        self.write_u8((num >> 8) as u8);
     }
-    // Write one byte at a specific position.
-    // The position must already be written (i.e. encoder.len > pos).
-    pub fn set(&mut self, pos: usize, byte: u8) {
-        self.buf[pos] = byte;
+
+    /// Write an unsigned integer (32bit)
+    pub fn write_u32(&mut self, num: u32) {
+        self.write_u8(num as u8);
+        self.write_u8((num >> 8) as u8);
+        self.write_u8((num >> 16) as u8);
+        self.write_u8((num >> 24) as u8);
     }
-    // Write an unsigned integer (8bit)
-    pub fn write_uint8(&mut self, num: u8) {
-        self.write(num);
+
+    /// Write an unsigned integer (32bit) in big endian order (most significant byte first)
+    pub fn write_u32_be(&mut self, num: u32) {
+        self.write_u8((num >> 24) as u8);
+        self.write_u8((num >> 16) as u8);
+        self.write_u8((num >> 8) as u8);
+        self.write_u8(num as u8);
     }
-    // Write an unsigned integer (8bit)
-    pub fn set_uint8(&mut self, pos: usize, num: u8) {
-        self.set(pos, num);
-    }
-    // Write an unsigned integer (16bit)
-    pub fn write_uint16(&mut self, num: u16) {
-        self.write(num as u8);
-        self.write((num >> 8) as u8);
-    }
-    // Write an unsigned integer (16bit)
-    pub fn set_uint16(&mut self, pos: usize, num: u16) {
-        self.set(pos, num as u8);
-        self.set(pos + 1, (num >> 8) as u8);
-    }
-    // Write an unsigned integer (32bit)
-    pub fn write_uint32(&mut self, num: u32) {
-        self.write(num as u8);
-        self.write((num >> 8) as u8);
-        self.write((num >> 16) as u8);
-        self.write((num >> 24) as u8);
-    }
-    // Write an unsigned integer (32bit)
-    pub fn set_uint32(&mut self, pos: usize, num: u32) {
-        self.set(pos, num as u8);
-        self.set(pos + 1, (num >> 8) as u8);
-        self.set(pos + 2, (num >> 16) as u8);
-        self.set(pos + 3, (num >> 24) as u8);
-    }
-    // Write an unsigned integer (32bit) in big endian order (most significant byte first)
-    pub fn write_uint32_big_endian(&mut self, num: u32) {
-        self.write((num >> 24) as u8);
-        self.write((num >> 16) as u8);
-        self.write((num >> 8) as u8);
-        self.write(num as u8);
-    }
-    // Write a variable length unsigned integer.
-    pub fn write_var_uint(&mut self, mut num: impl Uint) {
+
+    /// Write a variable length unsigned integer.
+    pub fn write_uvar(&mut self, mut num: impl Uint) {
         while {
             let rest = num.shift7_rest_to_byte();
             let c = !num.is_null();
-            self.write(if c { 0b10000000 | rest } else { rest });
+            self.write_u8(if c { 0b10000000 | rest } else { rest });
             c
         } {}
     }
-    // Write a variable length integer.
-    //
-    // We don't use zig-zag encoding because we want to keep the option open
-    // to use the same function for BigInt and 53bit integers.
-    //
-    // We use the 7th bit instead for signaling that this is a negative number.
+
+    /// Write a variable length integer.
+    ///
+    /// We don't use zig-zag encoding because we want to keep the option open
+    /// to use the same function for BigInt and 53bit integers.
+    ///
+    /// We use the 7th bit instead for signaling that this is a negative number.
     // @todo Support up to 128 bit
-    pub fn write_var_int(&mut self, mut num: i64) {
+    pub fn write_ivar(&mut self, mut num: i64) {
         let is_negative = num < 0;
         num = if is_negative { -num } else { num };
-        self.write(
+        self.write_u8(
             // whether to continue reading
             (if num > binary::BITS6 as i64 { binary::BIT8 as u8 } else { 0 })
                 // whether number is negative
@@ -96,7 +74,7 @@ impl Encoder {
         );
         num >>= 6;
         while num > 0 {
-            self.write(
+            self.write_u8(
                 if num > binary::BITS7 as i64 {
                     binary::BIT8 as u8
                 } else {
@@ -106,140 +84,45 @@ impl Encoder {
             num >>= 7;
         }
     }
-    // Write buffer without storing the length of the buffer
-    pub fn write_buffer(&mut self, buf: &[u8]) {
+
+    /// Write buffer without storing the length of the buffer
+    pub fn write(&mut self, buf: &[u8]) {
         self.buf.write(buf).unwrap();
     }
-    // Write variable length buffer (binary content).
-    pub fn write_var_buffer(&mut self, buf: &[u8]) {
-        self.write_var_uint(buf.len());
-        self.write_buffer(buf);
-    }
-    // Write variable-length utf8 string
-    pub fn write_var_string(&mut self, str: &str) {
-        self.write_var_buffer(str.as_bytes());
-    }
-    // Write floating point number in 4 bytes
-    pub fn write_float32(&mut self, num: f32) {
-        self.write_buffer(&num.to_be_bytes());
-    }
-    // Write floating point number in 8 bytes
-    pub fn write_float64(&mut self, num: f64) {
-        self.write_buffer(&num.to_be_bytes());
-    }
-    // Write BigInt in 8 bytes in big endian order.
-    // @deprecated This method is here for compatibility to lib0/encoding. Instead you should use
-    // write_int_64;
-    pub fn write_big_int64(&mut self, num: i64) {
-        self.write_buffer(&num.to_be_bytes());
-    }
-    // Write BigUInt in 8 bytes in big endian order.
-    // @deprecated This method is here for compatibility to lib0/encoding. Instead you should use
-    // write_int_64;
-    pub fn write_big_uint64(&mut self, num: u64) {
-        self.write_buffer(&num.to_be_bytes());
-    }
-    // Encode data with efficient binary format.
-    //
-    // Differences to JSON:
-    // • Transforms data to a binary format (not to a string)
-    // • Encodes undefined, NaN, and ArrayBuffer (these can't be represented in JSON)
-    // • Numbers are efficiently encoded either as a variable length integer, as a
-    //   32 bit float, as a 64 bit float, or as a 64 bit bigint.
-    //
-    // Encoding table:
-    //
-    // | Data Type           | Prefix   | Encoding Method    | Comment |
-    // | ------------------- | -------- | ------------------ | ------- |
-    // | undefined           | 127      |                    | Functions, symbol, and everything that cannot be identified is encoded as undefined |
-    // | null                | 126      |                    | |
-    // | integer             | 125      | writeVarInt        | Only encodes 32 bit signed integers |
-    // | float32             | 124      | writeFloat32       | |
-    // | float64             | 123      | writeFloat64       | |
-    // | bigint              | 122      | writeBigInt64      | |
-    // | boolean (false)     | 121      |                    | True and false are different data types so we save the following byte |
-    // | boolean (true)      | 120      |                    | - 0b01111000 so the last bit determines whether true or false |
-    // | string              | 119      | writeVarString     | |
-    // | object<string,any>  | 118      | custom             | Writes {length} then {length} key-value pairs |
-    // | array<any>          | 117      | custom             | Writes {length} then {length} json values |
-    // | Uint8Array          | 116      | writeVarUint8Array | We use Uint8Array for any kind of binary data |
-    //
-    // Reasons for the decreasing prefix:
-    // We need the first bit for extendability (later we may want to encode the
-    // prefix with writeVarUint). The remaining 7 bits are divided as follows:
-    // [0-30]   the beginning of the data range is used for custom purposes
-    //          (defined by the function that uses this library)
-    // [31-127] the end of the data range is used for data encoding by
-    //          lib0/encoding.js
-    pub fn write_any(&mut self, obj: &Any) {
-        match obj {
-            Any::Undefined => {
-                // TYPE 127: undefined
-                self.write(127)
-            }
-            Any::Null => {
-                // TYPE 126: null
-                self.write(126)
-            }
-            Any::Bool(bool) => {
-                // TYPE 120/121: boolean (true/false)
-                self.write(if *bool { 120 } else { 121 })
-            }
-            Any::String(str) => {
-                // TYPE 119: String
-                self.write(119);
-                self.write_var_string(&str);
-            }
-            Any::Number(num) => {
-                let num_truncated = num.trunc();
-                if num_truncated == *num
-                    && num_truncated <= crate::number::F64_MAX_SAFE_INTEGER
-                    && num_truncated >= crate::number::F64_MIN_SAFE_INTEGER
-                {
-                    // TYPE 125: INTEGER
-                    self.write(125);
-                    self.write_var_int(num_truncated as i64);
-                } else if is_float_32(*num) {
-                    // TYPE 124: FLOAT32
-                    self.write(124);
-                    self.write_float32(*num as f32);
-                } else {
-                    // TYPE 123: FLOAT64
-                    self.write(123);
-                    self.write_float64(*num);
-                }
-            }
-            Any::BigInt(num) => {
-                // TYPE 122: BigInt
-                self.write(122);
-                self.write_big_int64(*num);
-            }
-            Any::Array(arr) => {
-                // TYPE 117: Array
-                self.write(117);
-                self.write_var_uint(arr.len() as u64);
-                for el in arr.iter() {
-                    self.write_any(el);
-                }
-            }
-            Any::Map(map) => {
-                // TYPE 118: Map
-                self.write(118);
-                self.write_var_uint(map.len() as u64);
-                for (key, value) in map {
-                    self.write_var_string(&key);
-                    self.write_any(value);
-                }
-            }
-            Any::Buffer(buf) => {
-                // TYPE 116: Buffer
-                self.write(116);
-                self.write_var_buffer(&buf)
-            }
-        }
-    }
-}
 
-pub fn is_float_32(num: f64) -> bool {
-    ((num as f32) as f64) == num
+    /// Write variable length buffer (binary content).
+    pub fn write_buf<B: AsRef<[u8]>>(&mut self, buf: B) {
+        let buf = buf.as_ref();
+        self.write_uvar(buf.len());
+        self.write(buf);
+    }
+
+    /// Write variable-length utf8 string
+    pub fn write_string(&mut self, str: &str) {
+        self.write_buf(str);
+    }
+
+    /// Write floating point number in 4 bytes
+    pub fn write_f32(&mut self, num: f32) {
+        self.write(&num.to_be_bytes());
+    }
+
+    /// Write floating point number in 8 bytes
+    pub fn write_f64(&mut self, num: f64) {
+        self.write(&num.to_be_bytes());
+    }
+
+    /// Write BigInt in 8 bytes in big endian order.
+    // @deprecated This method is here for compatibility to lib0/encoding. Instead you should use
+    // write_int_64;
+    pub fn write_i64(&mut self, num: i64) {
+        self.write(&num.to_be_bytes());
+    }
+
+    /// Write BigUInt in 8 bytes in big endian order.
+    // @deprecated This method is here for compatibility to lib0/encoding. Instead you should use
+    // write_int_64;
+    pub fn write_u64(&mut self, num: u64) {
+        self.write(&num.to_be_bytes());
+    }
 }

--- a/lib0/tests/encoding_test.rs
+++ b/lib0/tests/encoding_test.rs
@@ -27,9 +27,9 @@ proptest! {
     #[test]
     fn encoding_any_prop(any in arb_any()) {
         let mut encoder = Encoder::new();
-        encoder.write_any(&any);
+        any.encode(&mut encoder);
         let mut decoder = Decoder::new(&encoder.buf);
-        let copy = decoder.read_any();
+        let copy = Any::decode(&mut decoder);
         assert_eq!(any, copy);
     }
 }
@@ -60,100 +60,100 @@ enum EncodingTypes {
 impl EncodingTypes {
     fn write(&self, encoder: &mut Encoder) {
         match self {
-            EncodingTypes::Byte(input) => encoder.write(*input),
+            EncodingTypes::Byte(input) => encoder.write_u8(*input),
             EncodingTypes::Uint8(input) => {
-                encoder.write_uint8(*input);
+                encoder.write_u8(*input);
             }
             EncodingTypes::Uint16(input) => {
-                encoder.write_uint16(*input);
+                encoder.write_u16(*input);
             }
             EncodingTypes::Uint32(input) => {
-                encoder.write_uint32(*input);
+                encoder.write_u32(*input);
             }
             EncodingTypes::Uint32BigEndian(input) => {
-                encoder.write_uint32_big_endian(*input);
+                encoder.write_u32_be(*input);
             }
             EncodingTypes::VarUint32(input) => {
-                encoder.write_var_uint(*input);
+                encoder.write_uvar(*input);
             }
             EncodingTypes::VarUint64(input) => {
-                encoder.write_var_uint(*input);
+                encoder.write_uvar(*input);
             }
             EncodingTypes::VarUint128(input) => {
-                encoder.write_var_uint(*input);
+                encoder.write_uvar(*input);
             }
             EncodingTypes::VarUintUsize(input) => {
-                encoder.write_var_uint(*input);
+                encoder.write_uvar(*input);
             }
             EncodingTypes::VarInt(input) => {
-                encoder.write_var_int(*input);
+                encoder.write_ivar(*input);
             }
             EncodingTypes::Buffer(input) => {
-                encoder.write_buffer(input);
+                encoder.write(input);
             }
             EncodingTypes::VarBuffer(input) => {
-                encoder.write_var_buffer(input);
+                encoder.write_buf(input);
             }
             EncodingTypes::VarString(input) => {
-                encoder.write_var_string(input);
+                encoder.write_string(input);
             }
             EncodingTypes::Float32(input) => {
-                encoder.write_float32(*input);
+                encoder.write_f32(*input);
             }
             EncodingTypes::Float64(input) => {
-                encoder.write_float64(*input);
+                encoder.write_f64(*input);
             }
             EncodingTypes::BigInt64(input) => {
-                encoder.write_big_int64(*input);
+                encoder.write_i64(*input);
             }
             EncodingTypes::BigUInt64(input) => {
-                encoder.write_big_uint64(*input);
+                encoder.write_u64(*input);
             }
             EncodingTypes::Any(input) => {
-                encoder.write_any(input);
+                input.encode(encoder);
             }
         }
     }
     fn read(&self, decoder: &mut Decoder) {
         match self {
             EncodingTypes::Byte(input) => {
-                let read = decoder.read();
+                let read = decoder.read_u8();
                 assert_eq!(read, *input);
             }
             EncodingTypes::Uint8(input) => {
-                let read = decoder.read_uint8();
+                let read = decoder.read_u8();
                 assert_eq!(read, *input);
             }
             EncodingTypes::Uint16(input) => {
-                let read = decoder.read_uint16();
+                let read = decoder.read_u16();
                 assert_eq!(read, *input);
             }
             EncodingTypes::Uint32(input) => {
-                let read = decoder.read_uint32();
+                let read = decoder.read_u32();
                 assert_eq!(read, *input);
             }
             EncodingTypes::Uint32BigEndian(input) => {
-                let read = decoder.read_uint32_big_endian();
+                let read = decoder.read_u32_be();
                 assert_eq!(read, *input);
             }
             EncodingTypes::VarUint32(input) => {
-                let read: u32 = decoder.read_var_uint();
+                let read: u32 = decoder.read_uvar();
                 assert_eq!(read, *input);
             }
             EncodingTypes::VarUint64(input) => {
-                let read: u64 = decoder.read_var_uint();
+                let read: u64 = decoder.read_uvar();
                 assert_eq!(read, *input);
             }
             EncodingTypes::VarUint128(input) => {
-                let read: u128 = decoder.read_var_uint();
+                let read: u128 = decoder.read_uvar();
                 assert_eq!(read, *input);
             }
             EncodingTypes::VarUintUsize(input) => {
-                let read: usize = decoder.read_var_uint();
+                let read: usize = decoder.read_uvar();
                 assert_eq!(read, *input);
             }
             EncodingTypes::VarInt(input) => {
-                let read = decoder.read_var_int();
+                let read = decoder.read_ivar();
                 assert_eq!(read, *input);
             }
             EncodingTypes::Buffer(input) => {
@@ -165,27 +165,27 @@ impl EncodingTypes {
                 assert_eq!(read, *input);
             }
             EncodingTypes::VarString(input) => {
-                let read = decoder.read_var_string();
+                let read = decoder.read_string();
                 assert_eq!(read, *input);
             }
             EncodingTypes::Float32(input) => {
-                let read = decoder.read_float32();
+                let read = decoder.read_f32();
                 assert_eq!(read, *input);
             }
             EncodingTypes::Float64(input) => {
-                let read = decoder.read_float64();
+                let read = decoder.read_f64();
                 assert_eq!(read, *input);
             }
             EncodingTypes::BigInt64(input) => {
-                let read = decoder.read_bigint64();
+                let read = decoder.read_i64();
                 assert_eq!(read, *input);
             }
             EncodingTypes::BigUInt64(input) => {
-                let read = decoder.read_big_uint64();
+                let read = decoder.read_u64();
                 assert_eq!(read, *input);
             }
             EncodingTypes::Any(input) => {
-                let read = decoder.read_any();
+                let read = Any::decode(decoder);
                 assert_eq!(read, *input);
             }
         }

--- a/yrs/src/event.rs
+++ b/yrs/src/event.rs
@@ -1,7 +1,6 @@
 use rand::RngCore;
-use std::cell::{RefCell, RefMut};
+use std::cell::RefCell;
 use std::collections::HashMap;
-use std::pin::Pin;
 use std::rc::{Rc, Weak};
 
 pub struct EventHandler<T>(Rc<RefCell<Subscriptions<T>>>);

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -104,11 +104,11 @@ impl Store {
     }
 
     pub fn read_blocks(&mut self, update_decoder: &mut updates::decoder::DecoderV1) {
-        let number_of_clients: u32 = update_decoder.rest_decoder.read_var_uint();
+        let number_of_clients: u32 = update_decoder.rest_decoder.read_uvar();
         for _ in 0..number_of_clients {
-            let number_of_structs: u32 = update_decoder.rest_decoder.read_var_uint();
+            let number_of_structs: u32 = update_decoder.rest_decoder.read_uvar();
             let client = update_decoder.read_client();
-            let mut clock = update_decoder.rest_decoder.read_var_uint();
+            let mut clock = update_decoder.rest_decoder.read_uvar();
             for _ in 0..number_of_structs {
                 let info = update_decoder.read_info();
                 // we will get parent from either left, right. Otherwise, we
@@ -183,7 +183,7 @@ impl Store {
             // @todo this could be optimized
             .filter(|(client_id, sl)| sv.get_state(**client_id) < sl.get_state())
             .collect();
-        update_encoder.rest_encoder.write_var_uint(structs.len());
+        update_encoder.rest_encoder.write_uvar(structs.len());
 
         for (client_id, client_structs) in structs.iter() {
             let start_clock = sv.get_state(**client_id);
@@ -191,8 +191,8 @@ impl Store {
             update_encoder.write_client(**client_id);
             update_encoder
                 .rest_encoder
-                .write_var_uint(client_structs.integrated_len as u32 - start_pivot);
-            update_encoder.rest_encoder.write_var_uint(start_clock); // initial clock
+                .write_uvar(client_structs.integrated_len as u32 - start_pivot);
+            update_encoder.rest_encoder.write_uvar(start_clock); // initial clock
             for i in (start_pivot as usize)..(client_structs.integrated_len) {
                 client_structs.list[i].encode(self, update_encoder);
             }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -1,8 +1,8 @@
 use crate::block::{HAS_ORIGIN, HAS_RIGHT_ORIGIN};
 use crate::block_store::{BlockStore, ClientBlockList, StateVector};
-use crate::updates::decoder::UpdateDecoder;
-use crate::updates::encoder::UpdateEncoder;
-use crate::{block, types, updates};
+use crate::updates::decoder::Decoder;
+use crate::updates::encoder::Encoder;
+use crate::{block, types};
 use std::collections::HashMap;
 
 pub struct Store {
@@ -103,19 +103,19 @@ impl Store {
         local_block_list.integrated_len += 1;
     }
 
-    pub fn read_blocks(&mut self, update_decoder: &mut updates::decoder::DecoderV1) {
-        let number_of_clients: u32 = update_decoder.rest_decoder.read_uvar();
+    pub fn read_blocks<D: Decoder>(&mut self, decoder: &mut D) {
+        let number_of_clients: u32 = decoder.read_uvar();
         for _ in 0..number_of_clients {
-            let number_of_structs: u32 = update_decoder.rest_decoder.read_uvar();
-            let client = update_decoder.read_client();
-            let mut clock = update_decoder.rest_decoder.read_uvar();
+            let number_of_structs: u32 = decoder.read_uvar();
+            let client = decoder.read_client();
+            let mut clock = decoder.read_uvar();
             for _ in 0..number_of_structs {
-                let info = update_decoder.read_info();
+                let info = decoder.read_info();
                 // we will get parent from either left, right. Otherwise, we
                 // read it from update_decoder.
                 let mut parent: Option<types::TypePtr> = None;
                 let (origin, left) = if info & HAS_ORIGIN == HAS_ORIGIN {
-                    let id = update_decoder.read_left_id();
+                    let id = decoder.read_left_id();
                     let ptr = self.blocks.find_item_ptr(&id);
                     parent = Some(self.blocks.get_item(&ptr).parent.clone());
                     (Some(id), Some(ptr))
@@ -123,7 +123,7 @@ impl Store {
                     (None, None)
                 };
                 let (right_origin, right) = if info & HAS_RIGHT_ORIGIN == HAS_RIGHT_ORIGIN {
-                    let id = update_decoder.read_right_id();
+                    let id = decoder.read_right_id();
                     let ptr = self.blocks.find_item_ptr(&id);
                     if info & HAS_ORIGIN != HAS_ORIGIN {
                         // only set parent if not already done so above
@@ -135,17 +135,17 @@ impl Store {
                 };
                 if info & (HAS_RIGHT_ORIGIN | HAS_ORIGIN) == 0 {
                     // neither origin nor right_origin is defined
-                    let parent_info = update_decoder.read_parent_info();
+                    let parent_info = decoder.read_parent_info();
                     if parent_info {
-                        let type_name = update_decoder.read_string();
+                        let type_name = decoder.read_string();
                         let type_name_ref = self.init_type_ref(type_name);
                         parent = Some(types::TypePtr::NamedRef(type_name_ref as u32));
                     } else {
-                        let id = update_decoder.read_left_id();
+                        let id = decoder.read_left_id();
                         parent = Some(types::TypePtr::Id(block::BlockPtr::from(id)));
                     }
                 };
-                let string_content = update_decoder.read_string();
+                let string_content = decoder.read_string();
                 let content = block::ItemContent::String(string_content.to_owned());
                 let item = block::Item {
                     id: block::ID { client, clock },
@@ -173,7 +173,7 @@ impl Store {
         }
     }
 
-    pub fn write_blocks(&self, update_encoder: &mut updates::encoder::EncoderV1, sv: &StateVector) {
+    pub fn write_blocks<E: Encoder>(&self, encoder: &mut E, sv: &StateVector) {
         // turns this into a vector because at some point we want to sort this
         // @todo Sort for better perf!
         let structs: Vec<(&u64, &ClientBlockList)> = self
@@ -183,18 +183,16 @@ impl Store {
             // @todo this could be optimized
             .filter(|(client_id, sl)| sv.get_state(**client_id) < sl.get_state())
             .collect();
-        update_encoder.rest_encoder.write_uvar(structs.len());
+        encoder.write_uvar(structs.len());
 
         for (client_id, client_structs) in structs.iter() {
             let start_clock = sv.get_state(**client_id);
             let start_pivot = client_structs.find_pivot(start_clock).unwrap() as u32;
-            update_encoder.write_client(**client_id);
-            update_encoder
-                .rest_encoder
-                .write_uvar(client_structs.integrated_len as u32 - start_pivot);
-            update_encoder.rest_encoder.write_uvar(start_clock); // initial clock
+            encoder.write_client(**client_id);
+            encoder.write_uvar(client_structs.integrated_len as u32 - start_pivot);
+            encoder.write_uvar(start_clock); // initial clock
             for i in (start_pivot as usize)..(client_structs.integrated_len) {
-                client_structs.list[i].encode(self, update_encoder);
+                client_structs.list[i].encode(self, encoder);
             }
         }
     }

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -63,7 +63,7 @@ impl<'a> Transaction<'a> {
         let mut update_encoder = updates::encoder::EncoderV1::new();
         self.store
             .write_blocks(&mut update_encoder, &self.timestamp);
-        update_encoder.to_buffer()
+        update_encoder.to_vec()
     }
 
     pub fn iterate_structs<F>(&mut self, client: &u64, clock_start: u32, len: u32, f: &F)

--- a/yrs/src/updates/decoder.rs
+++ b/yrs/src/updates/decoder.rs
@@ -52,47 +52,47 @@ pub trait UpdateDecoder: DSDecoder {
 impl<'a> UpdateDecoder for DecoderV1<'a> {
     fn read_left_id(&mut self) -> block::ID {
         block::ID {
-            client: self.rest_decoder.read_var_uint(),
-            clock: self.rest_decoder.read_var_uint(),
+            client: self.rest_decoder.read_uvar(),
+            clock: self.rest_decoder.read_uvar(),
         }
     }
 
     fn read_right_id(&mut self) -> block::ID {
         block::ID {
-            client: self.rest_decoder.read_var_uint(),
-            clock: self.rest_decoder.read_var_uint(),
+            client: self.rest_decoder.read_uvar(),
+            clock: self.rest_decoder.read_uvar(),
         }
     }
 
     fn read_client(&mut self) -> u64 {
-        self.rest_decoder.read_var_uint()
+        self.rest_decoder.read_uvar()
     }
 
     fn read_info(&mut self) -> u8 {
-        self.rest_decoder.read_uint8()
+        self.rest_decoder.read_u8()
     }
 
     fn read_string(&mut self) -> &str {
-        self.rest_decoder.read_var_string()
+        self.rest_decoder.read_string()
     }
 
     fn read_parent_info(&mut self) -> bool {
-        let info: u32 = self.rest_decoder.read_var_uint();
+        let info: u32 = self.rest_decoder.read_uvar();
         info == 1
     }
 
     fn read_type_ref(&mut self) -> TypeRefs {
         // In Yjs we use read_var_uint but use only 7 bit. So this is equivalent.
-        let r = self.rest_decoder.read_uint8();
+        let r = self.rest_decoder.read_u8();
         r.try_into().unwrap()
     }
 
     fn read_len(&mut self) -> u32 {
-        self.rest_decoder.read_var_uint()
+        self.rest_decoder.read_uvar()
     }
 
     fn read_any(&mut self) -> Any {
-        self.rest_decoder.read_any()
+        Any::decode(&mut self.rest_decoder)
     }
 
     fn read_buffer(&mut self) -> &[u8] {
@@ -100,6 +100,6 @@ impl<'a> UpdateDecoder for DecoderV1<'a> {
     }
 
     fn read_key(&mut self) -> &str {
-        self.rest_decoder.read_var_string()
+        self.rest_decoder.read_string()
     }
 }

--- a/yrs/src/updates/encoder.rs
+++ b/yrs/src/updates/encoder.rs
@@ -1,104 +1,100 @@
 use crate::*;
-use lib0::{any::Any, encoding::Encoder};
+use lib0::any::Any;
+use lib0::encoding::Write;
 
-pub trait DSEncoder {
-    fn rest_encoder(&mut self) -> &mut Encoder;
-    fn to_buffer(self) -> Vec<u8>;
+pub trait Encoder: Write {
+    fn to_vec(self) -> Vec<u8>;
     fn reset_ds_cur_val(&mut self);
     fn write_ds_clock(&mut self, clock: u32);
     fn write_ds_len(&mut self, len: u32);
+    fn write_left_id(&mut self, id: &block::ID);
+    fn write_right_id(&mut self, id: &block::ID);
+    fn write_client(&mut self, client: u64);
+    fn write_info(&mut self, info: u8);
+    fn write_parent_info(&mut self, is_y_key: bool);
+    fn write_type_ref(&mut self, info: u8);
+    fn write_len(&mut self, len: u32);
+    fn write_any(&mut self, any: &lib0::any::Any);
+    fn write_key(&mut self, string: &str);
 }
 
 pub struct EncoderV1 {
-    pub rest_encoder: Encoder,
+    buf: Vec<u8>,
 }
 
 impl EncoderV1 {
     pub fn new() -> Self {
         EncoderV1 {
-            rest_encoder: Encoder::new(),
+            buf: Vec::with_capacity(1024),
         }
     }
+
+    fn write_id(&mut self, id: &ID) {
+        self.write_uvar(id.client);
+        self.write_uvar(id.clock);
+    }
 }
 
-impl DSEncoder for EncoderV1 {
-    fn rest_encoder(&mut self) -> &mut Encoder {
-        &mut self.rest_encoder
+impl Write for EncoderV1 {
+    fn write_u8(&mut self, value: u8) {
+        self.buf.write_u8(value)
     }
-    fn to_buffer(self) -> Vec<u8> {
-        self.rest_encoder.buf
+
+    fn write(&mut self, buf: &[u8]) {
+        self.buf.write(buf)
     }
+}
+
+impl Encoder for EncoderV1 {
+    fn to_vec(self) -> Vec<u8> {
+        self.buf
+    }
+
     fn reset_ds_cur_val(&mut self) {
-        // nop
+        /* no op */
     }
+
     fn write_ds_clock(&mut self, clock: u32) {
-        self.rest_encoder.write_uvar(clock);
+        self.write_uvar(clock)
     }
+
     fn write_ds_len(&mut self, len: u32) {
-        self.rest_encoder.write_uvar(len);
-    }
-}
-
-pub trait UpdateEncoder: DSEncoder {
-    fn write_left_id(&mut self, id: &block::ID);
-    fn write_right_id(&mut self, id: &block::ID);
-    fn write_client(&mut self, client: u64);
-    fn write_info(&mut self, info: u8);
-    fn write_string(&mut self, s: &str);
-    fn write_parent_info(&mut self, is_y_key: bool);
-    fn write_type_ref(&mut self, info: u8);
-    fn write_len(&mut self, len: u32);
-    fn write_any(&mut self, any: &lib0::any::Any);
-    fn write_buffer(&mut self, buffer: &[u8]);
-    fn write_key(&mut self, string: &str);
-}
-
-impl UpdateEncoder for EncoderV1 {
-    fn write_left_id(&mut self, id: &block::ID) {
-        self.rest_encoder.write_uvar(id.client);
-        self.rest_encoder.write_uvar(id.clock);
+        self.write_uvar(len)
     }
 
-    fn write_right_id(&mut self, id: &block::ID) {
-        self.rest_encoder.write_uvar(id.client);
-        self.rest_encoder.write_uvar(id.clock);
+    fn write_left_id(&mut self, id: &ID) {
+        self.write_id(id)
+    }
+
+    fn write_right_id(&mut self, id: &ID) {
+        self.write_id(id)
     }
 
     fn write_client(&mut self, client: u64) {
-        self.rest_encoder.write_uvar(client);
+        self.write_uvar(client)
     }
 
     fn write_info(&mut self, info: u8) {
-        self.rest_encoder.write_u8(info);
-    }
-
-    fn write_string(&mut self, s: &str) {
-        self.rest_encoder.write_string(s);
+        self.write_u8(info)
     }
 
     fn write_parent_info(&mut self, is_y_key: bool) {
-        self.rest_encoder
-            .write_uvar(if is_y_key { 1 as u32 } else { 0 as u32 });
+        self.write_uvar(if is_y_key { 1 as u32 } else { 0 as u32 })
     }
 
     fn write_type_ref(&mut self, info: u8) {
-        // In Yjs we use read_var_uint but use only 7 bit. So this is equivalent.
-        self.rest_encoder.write_u8(info);
+        self.write_u8(info)
     }
 
     fn write_len(&mut self, len: u32) {
-        self.rest_encoder.write_uvar(len);
+        self.write_uvar(len)
     }
 
     fn write_any(&mut self, any: &Any) {
-        any.encode(&mut self.rest_encoder);
+        any.encode(self)
     }
 
-    fn write_buffer(&mut self, buffer: &[u8]) {
-        self.rest_encoder.write_buf(buffer);
-    }
-
-    fn write_key(&mut self, string: &str) {
-        self.rest_encoder.write_string(string);
+    fn write_key(&mut self, key: &str) {
+        self.write_string(key)
     }
 }

--- a/yrs/src/updates/encoder.rs
+++ b/yrs/src/updates/encoder.rs
@@ -32,10 +32,10 @@ impl DSEncoder for EncoderV1 {
         // nop
     }
     fn write_ds_clock(&mut self, clock: u32) {
-        self.rest_encoder.write_var_uint(clock);
+        self.rest_encoder.write_uvar(clock);
     }
     fn write_ds_len(&mut self, len: u32) {
-        self.rest_encoder.write_var_uint(len);
+        self.rest_encoder.write_uvar(len);
     }
 }
 
@@ -55,50 +55,50 @@ pub trait UpdateEncoder: DSEncoder {
 
 impl UpdateEncoder for EncoderV1 {
     fn write_left_id(&mut self, id: &block::ID) {
-        self.rest_encoder.write_var_uint(id.client);
-        self.rest_encoder.write_var_uint(id.clock);
+        self.rest_encoder.write_uvar(id.client);
+        self.rest_encoder.write_uvar(id.clock);
     }
 
     fn write_right_id(&mut self, id: &block::ID) {
-        self.rest_encoder.write_var_uint(id.client);
-        self.rest_encoder.write_var_uint(id.clock);
+        self.rest_encoder.write_uvar(id.client);
+        self.rest_encoder.write_uvar(id.clock);
     }
 
     fn write_client(&mut self, client: u64) {
-        self.rest_encoder.write_var_uint(client);
+        self.rest_encoder.write_uvar(client);
     }
 
     fn write_info(&mut self, info: u8) {
-        self.rest_encoder.write_uint8(info);
+        self.rest_encoder.write_u8(info);
     }
 
     fn write_string(&mut self, s: &str) {
-        self.rest_encoder.write_var_string(s);
+        self.rest_encoder.write_string(s);
     }
 
     fn write_parent_info(&mut self, is_y_key: bool) {
         self.rest_encoder
-            .write_var_uint(if is_y_key { 1 as u32 } else { 0 as u32 });
+            .write_uvar(if is_y_key { 1 as u32 } else { 0 as u32 });
     }
 
     fn write_type_ref(&mut self, info: u8) {
         // In Yjs we use read_var_uint but use only 7 bit. So this is equivalent.
-        self.rest_encoder.write_uint8(info);
+        self.rest_encoder.write_u8(info);
     }
 
     fn write_len(&mut self, len: u32) {
-        self.rest_encoder.write_var_uint(len);
+        self.rest_encoder.write_uvar(len);
     }
 
     fn write_any(&mut self, any: &Any) {
-        self.rest_encoder.write_any(any);
+        any.encode(&mut self.rest_encoder);
     }
 
     fn write_buffer(&mut self, buffer: &[u8]) {
-        self.rest_encoder.write_var_buffer(buffer);
+        self.rest_encoder.write_buf(buffer);
     }
 
     fn write_key(&mut self, string: &str) {
-        self.rest_encoder.write_var_string(string);
+        self.rest_encoder.write_string(string);
     }
 }


### PR DESCRIPTION
This PR does a bunch of things related to encoding/decoding:

1. Changes naming conventions to follow Rust style in remaining methods (eg. `write_uint32`&rarr;`write_u32`, `write_uint32_big_endian` &rarr; `write_u32_be`). I already did some of that in the past, now it's complete thru ought entire code base.
    - One thing Rust didn't precise was notion of var ints (as they are not Rust concept). There I used analogy: if Rust names 32-bit int as `i32` and 32-bit uint as `u32`, then I've changed `write_var_int`&rarr;`write_ivar` and `write_var_uint`&rarr;`write_uvar`.
2. Since lib0 `Encoder`/`Decoder` bear almost 1-to-1 resemblance to Rust [io::Read](https://doc.rust-lang.org/std/io/trait.Read.html) and [io::Write](https://doc.rust-lang.org/std/io/trait.Write.html) traits, I've abstracted their methods into lib0 `Read`/`Write` traits (the only difference from stdlib ones is that we panic on failure instead of returning errors, I decided to not change it... at least for now it seems to be quite invasive change).
    - I removed lib0 `Encoder` - the same features can now be implemented straight no top of Rust `Vec<u8>` data type - and potentially other types in the future as well.
    - I renamed lib0 `Decoder`&rarr;`Cursor` - again it's because it works just like Rust's [Cursor](https://doc.rust-lang.org/std/io/struct.Cursor.html) struct.
3. y-rs V1 Encoder/Decoder traits now implement lib0 Read/Write traits so they by default offer functions like reading/writing var ints.
    - Internals of encoder/decoder are now private as they don't need to be exposed anymore.
4. y-rs `DSEncoder` \ `UpdateEncoder` is now simplified into single `Encoder` trait (and same thing for decoder). Structs `EncoderV1`/`DecoderV1` simply implement corresponding traits.
5. All encoding/decoding methods in block_store and other types are now generic over `Encoder`/`Decoder` traits - this way when we're going to implement V2, all we need to do is to implement V2 version of encoder/decoder and no changes in types using them will be necessary.
6. Some of the methods that were not used (eg. `peek_u16`) were removed - we can reintroduce them, when we'll need them.

I've also run the initial tests we already have in place to make sure that changes are compatible with yjs-generated updates.