### PR TITLE
Benchmarks and fixes

### DIFF
--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -1389,7 +1389,6 @@ pub unsafe extern "C" fn yxmltext_len(txt: *const XmlText, txn: *const Transacti
     assert!(!txn.is_null());
 
     let txt = txt.as_ref().unwrap();
-    let txn = txn.as_ref().unwrap();
 
     txt.len() as c_int
 }
@@ -2869,13 +2868,15 @@ mod test {
         unsafe {
             let doc = ydoc_new();
             let txn = ytransaction_new(doc);
-            let array = yarray(txn, CString::new("test").unwrap().as_ptr());
+            let array_name = CString::new("test").unwrap();
+            let array = yarray(txn, array_name.as_ptr());
 
             let y_true = yinput_bool(Y_TRUE);
             let y_false = yinput_bool(Y_FALSE);
             let y_float = yinput_float(0.5);
             let y_int = yinput_long(11);
-            let y_str = yinput_string(CString::new("hello").unwrap().as_ptr());
+            let input = CString::new("hello").unwrap();
+            let y_str = yinput_string(input.as_ptr());
 
             let values = &[y_true, y_false, y_float, y_int, y_str];
 

--- a/yrs/benches/benches.rs
+++ b/yrs/benches/benches.rs
@@ -1,52 +1,425 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-use yrs::*;
+use criterion::*;
+use rand::distributions::Alphanumeric;
+use rand::prelude::ThreadRng;
+use rand::{thread_rng, Rng};
+use std::cell::Cell;
+use yrs::{Array, Doc, Text};
 
-const ITERATIONS: u32 = 1000000;
+enum TextOp {
+    Insert(u32, String),
+    Delete(u32, u32),
+}
 
-fn ytext_prepend() {
-    let doc = Doc::new();
-    let tr = &mut doc.transact();
-    let t = tr.get_text("");
-    for _ in 0..ITERATIONS {
-        t.insert(tr, 0, "a")
+enum ArrayOp {
+    Insert(u32, Vec<i32>),
+    Delete(u32, u32),
+}
+
+fn text_bench(doc: &Doc, text: &Text, ops: &Vec<TextOp>) {
+    for op in ops.iter() {
+        let mut txn = doc.transact();
+        match op {
+            TextOp::Insert(idx, txt) => text.insert(&mut txn, *idx, txt),
+            TextOp::Delete(idx, len) => text.remove_range(&mut txn, *idx, *len),
+        }
     }
 }
 
-fn ytext_append() {
-    let doc = Doc::new();
-    let tr = &mut doc.transact();
-    let t = tr.get_text("");
-    for i in 0..6000 {
-        t.insert(tr, i, "a")
+fn array_bench(doc: &Doc, array: &Array, ops: &Vec<ArrayOp>) {
+    for op in ops.iter() {
+        let mut txn = doc.transact();
+        match op {
+            ArrayOp::Insert(idx, values) => array.insert_range(&mut txn, *idx, values.clone()),
+            ArrayOp::Delete(idx, len) => array.remove_range(&mut txn, *idx, *len),
+        }
     }
 }
 
-const MULT_STRUCT_SIZE: u32 = 7;
+fn b1_1(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.1] Append N characters");
 
-fn gen_vec_perf_optimal() {
-    let mut vec: Vec<u64> = Vec::new();
-    for i in 0..((ITERATIONS * MULT_STRUCT_SIZE) as u64) {
-        vec.push(i);
+    fn gen_ops(size: usize) -> Vec<TextOp> {
+        let sample: Vec<_> = thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(size)
+            .map(|c| c.to_string())
+            .collect();
+
+        (0..size as u32)
+            .into_iter()
+            .zip(sample)
+            .map(|(i, str)| TextOp::Insert(i, str))
+            .collect()
     }
-}
 
-fn gen_vec_perf_pred_optimal() {
-    let mut vec: Vec<u64> = Vec::with_capacity((ITERATIONS * MULT_STRUCT_SIZE) as usize);
-    for i in 0..((ITERATIONS * MULT_STRUCT_SIZE) as u64) {
-        vec.push(i);
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let txt = txn.get_text("text");
+            (doc, txt, gen_ops(size as usize))
+        };
+
+        group.throughput(Throughput::Elements(size));
+        group.bench_with_input(
+            format!("[B1.1] Append {} characters", size),
+            &input,
+            |b, (doc, text, ops)| {
+                b.iter(|| text_bench(doc, text, ops));
+            },
+        );
     }
+    group.finish();
 }
 
-fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("ytext prepend", |b| b.iter(|| ytext_prepend()));
-    c.bench_function("ytext append", |b| b.iter(|| ytext_append()));
-    c.bench_function("gen vec perf optimal", |b| {
-        b.iter(|| gen_vec_perf_optimal())
-    });
-    c.bench_function("gen vec perf pred optimal", |b| {
-        b.iter(|| gen_vec_perf_pred_optimal())
-    });
+fn b1_2(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.2] Insert string of length N");
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let txt = txn.get_text("text");
+            let s: String = thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(size as usize)
+                .collect();
+            (doc, txt, vec![TextOp::Insert(0, s)])
+        };
+
+        group.throughput(Throughput::Elements(size));
+        group.bench_with_input(
+            format!("[B1.2] Insert string of length {}", size),
+            &input,
+            |b, (doc, txt, ops)| {
+                b.iter(|| text_bench(doc, txt, ops));
+            },
+        );
+    }
+    group.finish();
 }
 
-criterion_group!(benches, criterion_benchmark);
+fn b1_3(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.3] Prepend N characters");
+
+    fn gen_ops(size: usize) -> Vec<TextOp> {
+        let sample: Vec<_> = thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(size)
+            .map(|c| c.to_string())
+            .collect();
+
+        (0..size as u32)
+            .into_iter()
+            .zip(sample)
+            .map(|(i, str)| TextOp::Insert(0, str))
+            .collect()
+    }
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let txt = txn.get_text("text");
+            (doc, txt, gen_ops(size as usize))
+        };
+
+        group.throughput(Throughput::Elements(size));
+        group.bench_with_input(
+            format!("[B1.3] Prepend {} characters", size),
+            &input,
+            |b, (doc, text, ops)| {
+                b.iter(|| text_bench(doc, text, ops));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn b1_4(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.4] Insert N characters at random positions");
+
+    fn gen_ops(size: usize) -> Vec<TextOp> {
+        let mut rng = thread_rng();
+        let sample: Vec<_> = rng
+            .sample_iter(&Alphanumeric)
+            .take(size)
+            .map(|c| c.to_string())
+            .collect();
+
+        (0..size as u32)
+            .into_iter()
+            .zip(sample)
+            .map(|(i, str)| {
+                let idx = rng.gen_range(0, i.max(1));
+                TextOp::Insert(idx, str)
+            })
+            .collect()
+    }
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let txt = txn.get_text("text");
+            (doc, txt, gen_ops(size as usize))
+        };
+
+        group.throughput(Throughput::Elements(size));
+        group.bench_with_input(
+            format!("[B1.4] Insert {} characters at random positions", size),
+            &input,
+            |b, (doc, text, ops)| {
+                b.iter(|| text_bench(doc, text, ops));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn b1_5(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.5] Insert N words at random positions");
+
+    fn gen_string(rng: &mut ThreadRng, min: usize, max: usize) -> String {
+        let len = rng.gen_range(min, max);
+        rng.sample_iter(&Alphanumeric).take(len).collect()
+    }
+
+    fn gen_ops(size: usize) -> Vec<TextOp> {
+        let mut rng = thread_rng();
+        (0..size as u32)
+            .into_iter()
+            .map(|i| {
+                let str = gen_string(&mut rng, 2, 10);
+                let idx = rng.gen_range(0, i.max(1));
+                TextOp::Insert(idx, str)
+            })
+            .collect()
+    }
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let txt = txn.get_text("text");
+            (doc, txt, gen_ops(size as usize))
+        };
+
+        group.throughput(Throughput::Elements(size));
+        group.bench_with_input(
+            format!("[B1.5] Insert {} words at random positions", size),
+            &input,
+            |b, (doc, text, ops)| {
+                b.iter(|| text_bench(doc, text, ops));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn b1_6(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.6] Insert string, then delete it");
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let txt = txn.get_text("text");
+            let s: String = thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(size as usize)
+                .collect();
+            let len = s.len() as u32;
+            (doc, txt, vec![TextOp::Insert(0, s), TextOp::Delete(0, len)])
+        };
+
+        group.throughput(Throughput::Elements(size));
+        group.bench_with_input(
+            format!("[B1.6] Insert string of length {}, then delete it", size),
+            &input,
+            |b, (doc, text, ops)| {
+                b.iter(|| text_bench(doc, text, ops));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn b1_7(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.7] Insert/Delete strings at random positions");
+
+    fn gen_ops(size: usize) -> Vec<TextOp> {
+        let mut rng = thread_rng();
+        let mut total_len = Cell::new(0u32);
+        (0..size as u32)
+            .into_iter()
+            .map(|i| {
+                let total = total_len.get();
+                let idx = if total == 0 {
+                    0
+                } else {
+                    rng.gen_range(0, total)
+                };
+                if total == idx || rng.gen_bool(0.5) {
+                    let str = {
+                        let len = rng.gen_range(2, 10);
+                        total_len.set(total + len);
+                        rng.sample_iter(&Alphanumeric).take(len as usize).collect()
+                    };
+                    TextOp::Insert(idx, str)
+                } else {
+                    let hi = (total - idx).min(9);
+                    let len = if hi == 1 { 1 } else { rng.gen_range(1, hi) };
+                    total_len.set(total - len);
+                    TextOp::Delete(idx, len)
+                }
+            })
+            .collect()
+    }
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let txt = txn.get_text("text");
+            (doc, txt, gen_ops(size as usize))
+        };
+
+        group.throughput(Throughput::Elements(size));
+        group.bench_with_input(
+            format!("[B1.7] Insert/Delete {} strings at random positions", size),
+            &input,
+            |b, (doc, text, ops)| {
+                b.iter(|| text_bench(doc, text, ops));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn b1_8(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.8] Append N numbers");
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let mut rng = thread_rng();
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let array = txn.get_array("text");
+            let ops: Vec<ArrayOp> = (0..size)
+                .map(|i| ArrayOp::Insert(i, vec![rng.gen()]))
+                .collect();
+            (doc, array, ops)
+        };
+
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(
+            format!("[B1.8] Append {} numbers", size),
+            &input,
+            |b, (doc, array, ops)| {
+                b.iter(|| array_bench(doc, array, ops));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn b1_9(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.9] Insert Array of N numbers");
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let mut rng = thread_rng();
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let array = txn.get_array("text");
+            let sample: Vec<i32> = (0..size).map(|_| rng.gen()).collect();
+            (doc, array, vec![ArrayOp::Insert(0, sample)])
+        };
+
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(
+            format!("[B1.9] Insert Array of {} numbers", size),
+            &input,
+            |b, (doc, array, ops)| {
+                b.iter(|| array_bench(doc, array, ops));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn b1_10(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.10] Prepend N numbers");
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let mut rng = thread_rng();
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let array = txn.get_array("text");
+            let ops: Vec<ArrayOp> = (0..size)
+                .map(|i| ArrayOp::Insert(0, vec![rng.gen()]))
+                .collect();
+            (doc, array, ops)
+        };
+
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(
+            format!("[B1.10] Prepend {} numbers", size),
+            &input,
+            |b, (doc, array, ops)| {
+                b.iter(|| array_bench(doc, array, ops));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn b1_11(c: &mut Criterion) {
+    let mut group = c.benchmark_group("[B1.11] Insert N numbers at random positions");
+
+    for size in [1000, 3000, 6000] {
+        let input = {
+            let mut rng = thread_rng();
+            let doc = Doc::new();
+            let mut txn = doc.transact();
+            let array = txn.get_array("text");
+            let ops: Vec<ArrayOp> = (0..size)
+                .map(|i| {
+                    let idx = rng.gen_range(0, i.max(1));
+                    let values = vec![rng.gen()];
+                    ArrayOp::Insert(idx, values)
+                })
+                .collect();
+            (doc, array, ops)
+        };
+
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(
+            format!("[B1.11] Insert {} numbers at random positions", size),
+            &input,
+            |b, (doc, array, ops)| {
+                b.iter(|| array_bench(doc, array, ops));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench(c: &mut Criterion) {
+    b1_1(c);
+    b1_2(c);
+    b1_3(c);
+    b1_4(c);
+    b1_5(c);
+    b1_6(c);
+    b1_7(c);
+    b1_8(c);
+    b1_9(c);
+    b1_10(c);
+    b1_11(c);
+}
+
+criterion_group!(benches, bench);
 criterion_main!(benches);

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -9,6 +9,7 @@ use crate::*;
 use lib0::any::Any;
 use std::collections::HashSet;
 use std::hash::Hash;
+use std::ops::Deref;
 use std::panic;
 use std::rc::Rc;
 
@@ -950,16 +951,70 @@ impl Item {
             }
             ItemContent::Type(inner) => {
                 // this.type._integrate(transaction.doc, item)
-                //let ptr = Some(BlockPtr::new(self.id.clone(), pivot));
-                //match inner.try_borrow_mut() {
-                //    Ok(mut parent) => parent.item = ptr,
-                //    Err(_) => parent.item = ptr,
-                //}
             }
             _ => {
                 // other types don't define integration-specific actions
             }
         }
+    }
+}
+
+#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Clone)]
+pub struct Unicode(String, usize);
+
+impl Unicode {
+    #[inline(always)]
+    pub fn count(&self) -> usize {
+        self.1
+    }
+
+    pub fn split_at(&self, offset: usize) -> (&str, &str) {
+        let offset = self.0.char_indices().map(|(i, _)| i).nth(offset).unwrap();
+        self.0.split_at(offset)
+    }
+
+    pub fn push_str(&mut self, str: &str) {
+        let count = str.chars().count();
+        self.0.push_str(str);
+        self.1 += count;
+    }
+}
+
+impl std::fmt::Display for Unicode {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Into<String> for Unicode {
+    #[inline(always)]
+    fn into(self) -> String {
+        self.0
+    }
+}
+
+impl From<String> for Unicode {
+    fn from(str: String) -> Self {
+        let len = str.chars().count();
+        Unicode(str, len)
+    }
+}
+
+impl<'a> From<&'a str> for Unicode {
+    fn from(str: &'a str) -> Self {
+        let str = str.to_string();
+        let len = str.chars().count();
+        Unicode(str, len)
+    }
+}
+
+impl Deref for Unicode {
+    type Target = String;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -986,7 +1041,7 @@ pub enum ItemContent {
     Format(String, String), // key, value: JSON
 
     /// A chunk of text, usually applied by collaborative text insertion.
-    String(String),
+    String(Unicode),
 
     /// A reference of a branch node. Branch nodes define a complex collection types, such as
     /// arrays, maps or XML elements.
@@ -1042,7 +1097,7 @@ impl ItemContent {
     pub fn len(&self) -> u32 {
         match self {
             ItemContent::Deleted(deleted) => *deleted,
-            ItemContent::String(str) => str.chars().count() as u32,
+            ItemContent::String(str) => str.count() as u32,
             ItemContent::Any(v) => v.len() as u32,
             ItemContent::JSON(v) => v.len() as u32,
             _ => 1,
@@ -1086,7 +1141,7 @@ impl ItemContent {
             ItemContent::JSON(v) => v.last().map(|v| Value::Any(Any::String(v.clone()))),
             ItemContent::Embed(v) => Some(Value::Any(Any::String(v.clone()))),
             ItemContent::Format(_, _) => None,
-            ItemContent::String(v) => Some(Value::Any(Any::String(v.clone()))),
+            ItemContent::String(v) => Some(Value::Any(Any::String(v.clone().into()))),
             ItemContent::Type(c) => Some(c.clone().into_value(txn)),
         }
     }
@@ -1180,7 +1235,7 @@ impl ItemContent {
                 ItemContent::JSON(buf)
             }
             BLOCK_ITEM_BINARY_REF_NUMBER => ItemContent::Binary(decoder.read_buf().to_owned()),
-            BLOCK_ITEM_STRING_REF_NUMBER => ItemContent::String(decoder.read_string().to_owned()),
+            BLOCK_ITEM_STRING_REF_NUMBER => ItemContent::String(decoder.read_string().into()),
             BLOCK_ITEM_EMBED_REF_NUMBER => ItemContent::Embed(decoder.read_string().to_owned()),
             BLOCK_ITEM_FORMAT_REF_NUMBER => ItemContent::Format(
                 decoder.read_string().to_owned(),
@@ -1227,10 +1282,9 @@ impl ItemContent {
             }
             ItemContent::String(string) => {
                 // compute offset given in unicode code points into byte position
-                let offset = string.char_indices().map(|(i, _)| i).nth(offset).unwrap();
                 let (left, right) = string.split_at(offset);
-                let left = left.to_string();
-                let right = right.to_string();
+                let left: Unicode = left.into();
+                let right: Unicode = right.into();
 
                 //TODO: do we need that in Rust?
                 //let split_point = left.chars().last().unwrap();
@@ -1487,7 +1541,7 @@ pub struct PrelimText(pub String);
 
 impl Prelim for PrelimText {
     fn into_content(self, _txn: &mut Transaction, _ptr: TypePtr) -> (ItemContent, Option<Self>) {
-        (ItemContent::String(self.0), None)
+        (ItemContent::String(self.0.into()), None)
     }
 
     fn integrate(self, _txn: &mut Transaction, _inner_ref: BranchRef) {}

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -334,15 +334,6 @@ impl Block {
         }
     }
 
-    /// Returns an ID of a block, current item depends upon
-    /// (meaning: dependency must appear in the store before current item).
-    pub fn dependency(&self) -> Option<&ID> {
-        match self {
-            Block::Item(item) => item.dependency(),
-            _ => None,
-        }
-    }
-
     /// Checks if two blocks are of the same type.
     pub fn same_type(&self, other: &Self) -> bool {
         match (self, other) {
@@ -910,18 +901,6 @@ impl Item {
         }
     }
 
-    /// Returns an ID of a block, current item depends upon
-    /// (meaning: dependency must appear in the store before current item).
-    pub fn dependency(&self) -> Option<&ID> {
-        self.origin
-            .as_ref()
-            .or_else(|| self.right_origin.as_ref())
-            .or_else(|| match &self.parent {
-                TypePtr::Id(ptr) => Some(&ptr.id),
-                _ => None,
-            })
-    }
-
     fn info(&self) -> u8 {
         let info = if self.origin.is_some() { HAS_ORIGIN } else { 0 } // is left null
             | if self.right_origin.is_some() { HAS_RIGHT_ORIGIN } else { 0 } // is right null
@@ -930,7 +909,7 @@ impl Item {
         info
     }
 
-    fn integrate_content(&mut self, txn: &mut Transaction, pivot: u32, parent: &mut Branch) {
+    fn integrate_content(&mut self, txn: &mut Transaction, _pivot: u32, _parent: &mut Branch) {
         match &mut self.content {
             ItemContent::Deleted(len) => {
                 txn.delete_set.insert(self.id, *len);
@@ -949,7 +928,7 @@ impl Item {
                 // @todo searchmarker are currently unsupported for rich text documents
                 // /** @type {AbstractType<any>} */ (item.parent)._searchMarker = null
             }
-            ItemContent::Type(inner) => {
+            ItemContent::Type(_inner) => {
                 // this.type._integrate(transaction.doc, item)
             }
             _ => {

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -420,11 +420,6 @@ impl BlockStore {
         self.clients.is_empty()
     }
 
-    /// Checks if the were any blocks integrated from a given `client`.
-    pub fn contains_client(&self, client: &u64) -> bool {
-        self.clients.contains_key(client)
-    }
-
     /// Returns an immutable reference to a block list for a particular `client`. Returns `None` if
     /// no block list existed for provided `client` in current block store.
     pub fn get(&self, client: &u64) -> Option<&ClientBlockList> {

--- a/yrs/src/compatibility_tests.rs
+++ b/yrs/src/compatibility_tests.rs
@@ -98,7 +98,7 @@ fn text_insert_delete() {
     let setter = visited.clone();
 
     let mut doc = Doc::new();
-    let _sub = doc.on_update(move |txn, e| {
+    let _sub = doc.on_update(move |_, e| {
         for (actual, expected) in e.update.blocks.blocks().zip(expected_blocks.as_slice()) {
             assert_eq!(actual, expected);
         }

--- a/yrs/src/compatibility_tests.rs
+++ b/yrs/src/compatibility_tests.rs
@@ -55,7 +55,7 @@ fn text_insert_delete() {
             Some(ID::new(CLIENT_ID, 0)),
             TypePtr::Unknown,
             None,
-            ItemContent::String("ab".to_string()),
+            ItemContent::String("ab".into()),
         )),
         Block::Item(Item::new(
             ID::new(CLIENT_ID, 5),
@@ -85,7 +85,7 @@ fn text_insert_delete() {
             None,
             TypePtr::Unknown,
             None,
-            ItemContent::String("hi".to_string()),
+            ItemContent::String("hi".into()),
         )),
     ];
     let expected_ds = {

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -108,7 +108,7 @@ impl Doc {
     where
         F: Fn(&Transaction, &UpdateEvent) -> () + 'static,
     {
-        let mut store = unsafe { &mut *self.store.get() };
+        let store = unsafe { &mut *self.store.get() };
         store.update_events.subscribe(f)
     }
 }
@@ -214,7 +214,7 @@ mod test {
         let doc = Doc::new();
         let mut doc2 = Doc::new();
         let c = counter.clone();
-        let sub = doc2.on_update(move |txn, e| {
+        let sub = doc2.on_update(move |_txn, e| {
             for block in e.update.blocks.blocks() {
                 c.set(c.get() + block.len());
             }

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -96,7 +96,11 @@ impl IdRange {
         match self {
             IdRange::Continuous(r) => {
                 if r.end >= range.start {
-                    r.end = range.end; // two ranges overlap, we can eagerly merge them
+                    if r.start > range.end {
+                        *self = IdRange::Fragmented(vec![range, r.clone()])
+                    } else {
+                        r.end = range.end; // two ranges overlap, we can eagerly merge them
+                    }
                 } else {
                     *self = IdRange::Fragmented(vec![r.clone(), range])
                 }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -1,14 +1,13 @@
-use crate::block::{Block, BlockPtr, ItemContent};
+use crate::block::ItemContent;
 use crate::block_store::{BlockStore, SquashResult, StateVector};
 use crate::event::{EventHandler, UpdateEvent};
 use crate::id_set::DeleteSet;
+use crate::types;
 use crate::types::{BranchRef, Path, PathSegment, TypePtr, TypeRefs, TYPE_REFS_UNDEFINED};
 use crate::update::PendingUpdate;
 use crate::updates::encoder::{Encode, Encoder};
-use crate::{types, ID};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::ops::Range;
 use std::rc::Rc;
 
 /// Store is a core element of a document. It contains all of the information, like block store
@@ -133,52 +132,6 @@ impl Store {
         value.clone()
     }
 
-    pub(crate) fn find_index_clean_start(&mut self, client: &u64, clock: u32) -> Option<usize> {
-        let blocks = self.blocks.get_mut(client)?;
-        let index = blocks.find_pivot(clock)?;
-        let block = blocks.get_mut(index);
-        if let Some(item) = block.as_item_mut() {
-            if item.id.clock < clock {
-                // if we run over the clock, we need to the split item
-                let id = ID::new(*client, clock - item.id.clock);
-                self.blocks.split_block(&BlockPtr::new(id, index as u32));
-                return Some(index + 1);
-            }
-        }
-
-        Some(index)
-    }
-
-    pub(crate) fn iterate_structs<F>(&mut self, client: &u64, range: &Range<u32>, f: &F)
-    where
-        F: Fn(&Block) -> (),
-    {
-        let clock_start = range.start;
-        let clock_end = range.end;
-
-        if clock_start == clock_end {
-            return;
-        }
-
-        if let Some(mut index) = self.find_index_clean_start(client, clock_start) {
-            let mut blocks = self.blocks.get(client).unwrap();
-            let mut block = &blocks[index];
-
-            while index < blocks.len() && block.id().clock < clock_end {
-                if clock_end < block.clock_end() {
-                    self.find_index_clean_start(client, clock_start);
-                    blocks = self.blocks.get(client).unwrap();
-                    block = &blocks[index];
-                }
-
-                f(block);
-                index += 1;
-
-                block = &blocks[index];
-            }
-        }
-    }
-
     /// Compute a diff to sync with another client.
     ///
     /// This is the most efficient method to sync with another client by only
@@ -261,16 +214,6 @@ impl Store {
                 item.left = Some(compaction.replacement);
             }
         }
-    }
-
-    pub(crate) fn get_root_type_key(&self, value: &BranchRef) -> Option<&Rc<str>> {
-        for (k, v) in self.types.iter() {
-            if v == value {
-                return Some(k);
-            }
-        }
-
-        None
     }
 
     pub fn get_type_from_path(&self, path: &Path) -> Option<&BranchRef> {

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -197,7 +197,7 @@ impl Store {
         delete_set.encode(encoder);
     }
 
-    fn write_blocks<E: Encoder>(&self, remote_sv: &StateVector, encoder: &mut E) {
+    pub(crate) fn write_blocks<E: Encoder>(&self, remote_sv: &StateVector, encoder: &mut E) {
         let local_sv = self.blocks.get_state_vector();
         let mut diff = Self::diff_state_vectors(&local_sv, remote_sv);
 

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -120,7 +120,7 @@ impl TestConnector {
             let rc = self.0.clone();
             let inner = unsafe { self.0.as_ptr().as_mut().unwrap() };
             let mut instance = TestPeer::new(client_id);
-            instance.doc.on_update(move |txn, e| {
+            instance.doc.on_update(move |_, e| {
                 let payload = {
                     let mut encoder = EncoderV1::new();
                     encoder.write_uvar(MSG_SYNC_UPDATE);

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1,9 +1,9 @@
 use crate::*;
 
-use crate::block::{Block, BlockPtr, Item, ItemContent, Prelim, ID};
+use crate::block::{BlockPtr, Item, ItemContent, Prelim, ID};
 use crate::block_store::StateVector;
 use crate::event::UpdateEvent;
-use crate::id_set::{DeleteSet, IdSet};
+use crate::id_set::DeleteSet;
 use crate::store::Store;
 use crate::types::array::Array;
 use crate::types::xml::{XmlElement, XmlText};
@@ -164,21 +164,6 @@ impl Transaction {
         store.write_blocks(&self.before_state, &mut enc);
         self.delete_set.encode(&mut enc);
         enc.to_vec()
-    }
-
-    pub(crate) fn apply_ranges<F>(&mut self, set: &IdSet, f: &F)
-    where
-        F: Fn(&Block) -> (),
-    {
-        // equivalent of JS: Y.iterateDeletedStructs
-        let store = self.store_mut();
-        for (client, ranges) in set.iter() {
-            if store.blocks.contains_client(client) {
-                for range in ranges.iter() {
-                    store.iterate_structs(client, range, f);
-                }
-            }
-        }
     }
 
     /// Applies given `id_set` onto current transaction to run multi-range deletion.

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -598,9 +598,9 @@ mod test {
             let mut txn = d.transact();
             txn.get_array("array")
         };
-        let mut happened = Rc::new(Cell::new(false));
+        let happened = Rc::new(Cell::new(false));
         let happened_clone = happened.clone();
-        let _sub = array.observe(move |txn, e| {
+        let _sub = array.observe(move |_, _| {
             happened_clone.set(true);
         });
 
@@ -642,15 +642,15 @@ mod test {
             let mut txn = d1.transact();
             txn.get_array("array")
         };
-        let mut added = Rc::new(RefCell::new(None));
-        let mut removed = Rc::new(RefCell::new(None));
-        let mut delta = Rc::new(RefCell::new(None));
+        let added = Rc::new(RefCell::new(None));
+        let removed = Rc::new(RefCell::new(None));
+        let delta = Rc::new(RefCell::new(None));
 
         let (added_c, removed_c, delta_c) = (added.clone(), removed.clone(), delta.clone());
         let _sub = array.observe(move |txn, e| {
-            added_c.borrow_mut().insert(e.inserts(txn).clone());
-            removed_c.borrow_mut().insert(e.removes(txn).clone());
-            delta_c.borrow_mut().insert(e.delta(txn).to_vec());
+            *added_c.borrow_mut() = Some(e.inserts(txn).clone());
+            *removed_c.borrow_mut() = Some(e.removes(txn).clone());
+            *delta_c.borrow_mut() = Some(e.delta(txn).to_vec());
         });
 
         {
@@ -707,9 +707,9 @@ mod test {
         };
         let (added_c, removed_c, delta_c) = (added.clone(), removed.clone(), delta.clone());
         let _sub = array2.observe(move |txn, e| {
-            added_c.borrow_mut().insert(e.inserts(txn).clone());
-            removed_c.borrow_mut().insert(e.removes(txn).clone());
-            delta_c.borrow_mut().insert(e.delta(txn).to_vec());
+            *added_c.borrow_mut() = Some(e.inserts(txn).clone());
+            *removed_c.borrow_mut() = Some(e.removes(txn).clone());
+            *delta_c.borrow_mut() = Some(e.delta(txn).to_vec());
         });
 
         {
@@ -751,13 +751,13 @@ mod test {
 
         let c1 = Rc::new(RefCell::new(None));
         let c1c = c1.clone();
-        let _s1 = a1.observe(move |txn, e| {
-            c1c.borrow_mut().insert(e.target());
+        let _s1 = a1.observe(move |_, e| {
+            *c1c.borrow_mut() = Some(e.target());
         });
         let c2 = Rc::new(RefCell::new(None));
         let c2c = c2.clone();
-        let _s2 = a2.observe(move |txn, e| {
-            c2c.borrow_mut().insert(e.target());
+        let _s2 = a2.observe(move |_, e| {
+            *c2c.borrow_mut() = Some(e.target());
         });
 
         {

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -552,17 +552,17 @@ mod test {
 
     #[test]
     fn insert_and_remove_events() {
-        let mut d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(1);
         let m1 = {
             let mut txn = d1.transact();
             txn.get_map("map")
         };
 
-        let mut entries = Rc::new(RefCell::new(None));
-        let mut entries_c = entries.clone();
+        let entries = Rc::new(RefCell::new(None));
+        let entries_c = entries.clone();
         let _sub = m1.observe(move |txn, e| {
             let keys = e.keys(txn);
-            entries_c.borrow_mut().insert(keys.clone());
+            *entries_c.borrow_mut() = Some(keys.clone());
         });
 
         // insert new entry
@@ -642,17 +642,17 @@ mod test {
         assert_eq!(entries.take(), Some(HashMap::new()));
 
         // copy updates over
-        let mut d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(2);
         let m2 = {
             let mut txn = d2.transact();
             txn.get_map("map")
         };
 
-        let mut entries = Rc::new(RefCell::new(None));
-        let mut entries_c = entries.clone();
+        let entries = Rc::new(RefCell::new(None));
+        let entries_c = entries.clone();
         let _sub = m2.observe(move |txn, e| {
             let keys = e.keys(txn);
-            entries_c.borrow_mut().insert(keys.clone());
+            *entries_c.borrow_mut() = Some(keys.clone());
         });
 
         {

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -494,10 +494,10 @@ mod test {
             let mut txn = d1.transact();
             txn.get_text("text")
         };
-        let mut delta = Rc::new(RefCell::new(None));
+        let delta = Rc::new(RefCell::new(None));
         let delta_c = delta.clone();
         let _sub = txt.observe(move |txn, e| {
-            delta_c.borrow_mut().insert(e.delta(txn).to_vec());
+            *delta_c.borrow_mut() = Some(e.delta(txn).to_vec());
         });
 
         // insert initial string
@@ -549,7 +549,7 @@ mod test {
         };
         let delta_c = delta.clone();
         let _sub = txt.observe(move |txn, e| {
-            delta_c.borrow_mut().insert(e.delta(txn).to_vec());
+            *delta_c.borrow_mut() = Some(e.delta(txn).to_vec());
         });
 
         {
@@ -575,7 +575,7 @@ mod test {
 
     #[test]
     fn unicode_support() {
-        let mut d = Doc::with_client_id(1);
+        let d = Doc::with_client_id(1);
         let mut txn = d.transact();
         let txt = txn.get_text("test");
 

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -916,7 +916,7 @@ mod test {
         let r1 = t1.get_xml_element("root");
         let first = r1.push_text_back(&mut t1);
         first.push(&mut t1, "hello");
-        let second = r1.push_elem_back(&mut t1, "p");
+        r1.push_elem_back(&mut t1, "p");
 
         let expected = "<UNDEFINED>hello<p></p></UNDEFINED>";
         assert_eq!(r1.to_string(&t1), expected);
@@ -938,7 +938,7 @@ mod test {
         let r1 = t1.get_xml_element("root");
         let first = r1.push_text_back(&mut t1);
         first.push(&mut t1, "hello");
-        let second = r1.push_elem_back(&mut t1, "p");
+        r1.push_elem_back(&mut t1, "p");
 
         /* This binary is result of following Yjs code (matching Rust code above):
         ```js
@@ -962,19 +962,19 @@ mod test {
 
     #[test]
     fn event_observers() {
-        let mut d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(1);
         let xml = {
             let mut txn = d1.transact();
             txn.get_xml_element("xml")
         };
 
-        let mut attributes = Rc::new(RefCell::new(None));
-        let mut nodes = Rc::new(RefCell::new(None));
-        let mut attributes_c = attributes.clone();
-        let mut nodes_c = nodes.clone();
+        let attributes = Rc::new(RefCell::new(None));
+        let nodes = Rc::new(RefCell::new(None));
+        let attributes_c = attributes.clone();
+        let nodes_c = nodes.clone();
         let _sub = xml.observe(move |txn, e| {
-            attributes_c.borrow_mut().insert(e.keys(txn).clone());
-            nodes_c.borrow_mut().insert(e.delta(txn).to_vec());
+            *attributes_c.borrow_mut() = Some(e.keys(txn).clone());
+            *nodes_c.borrow_mut() = Some(e.delta(txn).to_vec());
         });
 
         // insert attribute
@@ -1055,19 +1055,19 @@ mod test {
         assert_eq!(attributes.borrow_mut().take(), Some(HashMap::new()));
 
         // copy updates over
-        let mut d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(2);
         let xml2 = {
             let mut txn = d2.transact();
             txn.get_xml_element("xml")
         };
 
-        let mut attributes = Rc::new(RefCell::new(None));
-        let mut nodes = Rc::new(RefCell::new(None));
-        let mut attributes_c = attributes.clone();
-        let mut nodes_c = nodes.clone();
+        let attributes = Rc::new(RefCell::new(None));
+        let nodes = Rc::new(RefCell::new(None));
+        let attributes_c = attributes.clone();
+        let nodes_c = nodes.clone();
         let _sub = xml2.observe(move |txn, e| {
-            attributes_c.borrow_mut().insert(e.keys(txn).clone());
-            nodes_c.borrow_mut().insert(e.delta(txn).to_vec());
+            *attributes_c.borrow_mut() = Some(e.keys(txn).clone());
+            *nodes_c.borrow_mut() = Some(e.delta(txn).to_vec());
         });
 
         {


### PR DESCRIPTION
Initial B.1 class benchmark results over incrementing sets of 1000/3000/6000 ops (compared against benchmarks from [https://github.com/dmonad/crdt-benchmarks](https://github.com/dmonad/crdt-benchmarks)):

[B1.1] Append N characters - time:   
 - N=1000: **761.37 us**
 - N=3000: **2.2541 ms**
 - N=6000: **4.5685 ms** (Yjs v13.3: 303 ms, Automerge v0.14: 2.460 s) - Yjs is 66x slower, Automerge is 538x slower

[B1.2] Insert string of length N - time:   
 - N=1000: **1.2714 us**
 - N=3000: **2.7022 us**
 - N=6000: **4.9906 us** (Yjs v13.3: 7 ms, Automerge v0.14: 2.981 s) - Yjs is 1,402x slower, Automerge is 597,394x slower

[B1.3] Prepend N characters - time:   
 - N=1000: **755.88 us**
 - N=3000: **2.3259 ms**
 - N=6000: **4.6414 ms** (Yjs v13.3: 280 ms, Automerge v0.14: 83.488 s) - Yjs is 60x slower, Automerge is 17,987x slower

[B1.4] Insert N characters at random positions - time:   
 - N=1000: **11.726 ms**
 - N=3000: **42.218 ms**
 - N=6000:  **272.60 ms** (Yjs v13.3: 311 ms, Automerge v0.14: 3.255 s) - Yjs is 14% slower, Automerge is 11x slower

[B1.5] Insert N words at random positions - time:   
 - N=1000:  **7.1984 ms**
 - N=3000: **63.854 ms**
 - N=6000: **260.08 ms** (Yjs v13.3: 376 ms, Automerge v0.14: 12.090 s) - Yjs is 45% slower, Automerge is 46x slower

[B1.6] Insert string of length N , then delete it - time:   
 - N=1000: **1.9513 us**
 - N=3000: **2.3883 us**
 - N=6000: **3.4065 us** (Yjs v13.3: 6 ms, Automerge v0.14: 2.715 s) - Yjs is 1,764x slower, Automerge is 798,529x slower

[B1.7] Insert/Delete N strings at random positions - time:   
 - N=1000: **24.856 ms**
 - N=3000: **213.11 ms**
 - N=6000: **850.96 ms** (Yjs v13.3: 378 ms, Automerge v0.14: 6.347 s) - Yjs is 56% faster, Automerge is 7x slower

[B1.8] Append N numbers - time:   
 - N=1000: **1.0141 ms**
 - N=3000: **3.0015 ms**
 - N=6000: **5.9492 ms** (Yjs v13.3: 330 ms, Automerge v0.14: 2.913 s) - Yjs is 55x slower, Automerge is 489x slower

[B1.9] Insert Array of N numbers - time:   
 - N=1000: **51.886 us**
 - N=3000: **146.44 us**
 - N=6000: **147.77 us** (Yjs v13.3: 14 ms, Automerge v0.14: 3.223 s) - Yjs is 94x slower, Automerge is 21,810x slower

[B1.10] Prepend N numbers - time: 
 - N=1000:  **1.1508 ms**
 - N=3000: **3.1238 ms**
 - N=6000: **6.2630 ms** (Yjs v13.3: 271 ms, Automerge v0.14: 62.982 s) - Yjs is 43x slower, Automerge is 10,056x slower

[B1.11] Insert N numbers at random positions - time:   
 - N=1000: **8.2624 ms**
 - N=3000: **89.724 ms**
 - N=6000: **341.01 ms** (Yjs v13.3: 296 ms, Automerge v0.14: 3.844 s) - Yjs is 14% faster, Automerge is 11x slower
 
> **DISCLAIMER**: this Yjs numbers is kinda apples-to-oranges comparison, so don't quote me on them - it's made just for sake of curiosity. Also, things like C-FFI/WASM interop almost always require adding some extra overhead due to necessary boxing rules, so numbers will be worse than when working from pure Rust (which these benchmarks refer to).

The only benchmarks that are worse than Yjs are the ones related to insertions at random positions. We should work on that.