### PR TITLE
Configurable charset encoding

### DIFF
--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -8,6 +8,15 @@ extern "C" {
     #include "include/libyrs.h"
 };
 
+YDoc* ydoc_new_with_id(int id) {
+    YOptions o;
+    o.encoding = Y_ENCODING_UTF16;
+    o.id = id;
+    o.skip_gc = 0;
+
+    return ydoc_new_with_options(o);
+}
+
 TEST_CASE("Update exchange basic") {
     // init
     YDoc* d1 = ydoc_new_with_id(1);

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -129,7 +129,7 @@ pub struct Options {
     /// Encoding used for text operations.
     pub encoding: Encoding,
     /// Determines if transactions commits should try to perform GC-ing of deleted items.
-    pub gc: bool,
+    pub skip_gc: bool,
 }
 
 impl Options {
@@ -137,7 +137,7 @@ impl Options {
         Options {
             client_id,
             encoding: Encoding::Bytes,
-            gc: true,
+            skip_gc: false,
         }
     }
 }

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -46,6 +46,8 @@ pub use crate::alt::{diff_updates, encode_state_vector_from_update, merge_update
 pub use crate::block::ID;
 pub use crate::block_store::StateVector;
 pub use crate::doc::Doc;
+pub use crate::doc::Encoding;
+pub use crate::doc::Options;
 pub use crate::id_set::DeleteSet;
 pub use crate::transaction::Transaction;
 pub use crate::types::array::Array;

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -1,5 +1,6 @@
 use crate::block::ItemContent;
 use crate::block_store::{BlockStore, SquashResult, StateVector};
+use crate::doc::Options;
 use crate::event::{EventHandler, UpdateEvent};
 use crate::id_set::DeleteSet;
 use crate::types;
@@ -14,8 +15,7 @@ use std::rc::Rc;
 /// map of root types, pending updates waiting to be applied once a missing update information
 /// arrives and all subscribed callbacks.
 pub(crate) struct Store {
-    /// An unique identifier of a current document replica.
-    pub client_id: u64,
+    pub options: Options,
 
     /// Root types (a.k.a. top-level types). These types are defined by users at the document level,
     /// they have their own unique names and represent core shared types that expose operations
@@ -43,9 +43,9 @@ pub(crate) struct Store {
 
 impl Store {
     /// Create a new empty store in context of a given `client_id`.
-    pub fn new(client_id: u64) -> Self {
+    pub fn new(options: Options) -> Self {
         Store {
-            client_id,
+            options,
             types: Default::default(),
             blocks: BlockStore::new(),
             pending: None,
@@ -59,7 +59,7 @@ impl Store {
     /// block that's about to be inserted. You cannot use that clock value to find any existing
     /// block content.
     pub fn get_local_state(&self) -> u32 {
-        self.blocks.get_state(&self.client_id)
+        self.blocks.get_state(&self.options.client_id)
     }
 
     /// Returns a branch reference to a complex type identified by its pointer. Returns `None` if
@@ -266,7 +266,7 @@ impl Encode for Store {
 
 impl std::fmt::Display for Store {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Store(ID: {}) {{", self.client_id)?;
+        writeln!(f, "Store(ID: {}) {{", self.options.client_id)?;
         if !self.types.is_empty() {
             writeln!(f, "\ttypes: {{")?;
             for (k, v) in self.types.iter() {

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -411,7 +411,7 @@ impl Transaction {
             } else {
                 None
             };
-            let client_id = store.client_id;
+            let client_id = store.options.client_id;
             let id = block::ID {
                 client: client_id,
                 clock: store.get_local_state(),

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -256,7 +256,8 @@ impl Transaction {
                 if item.parent_sub.is_none() && item.is_countable() {
                     if let Some(parent) = self.store().get_type(&item.parent) {
                         let mut inner = parent.borrow_mut();
-                        inner.len -= item.len();
+                        inner.block_len -= item.len();
+                        inner.content_len -= item.content_len(store.options.encoding);
                     }
                 }
 
@@ -484,7 +485,9 @@ impl Transaction {
         }
 
         // 4. try GC delete set
-        self.try_gc(); //TODO: eventually this is a configurable variant: if (doc.gc)
+        if !store.options.skip_gc {
+            self.try_gc();
+        }
 
         // 5. try merge delete set
         self.delete_set.try_squash_with(store);

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -2,6 +2,7 @@ use crate::block::{
     Block, BlockPtr, Item, ItemContent, Skip, BLOCK_GC_REF_NUMBER, BLOCK_SKIP_REF_NUMBER, GC,
     HAS_ORIGIN, HAS_PARENT_SUB, HAS_RIGHT_ORIGIN,
 };
+use crate::doc::Options;
 use crate::id_set::DeleteSet;
 #[cfg(test)]
 use crate::store::Store;
@@ -691,7 +692,7 @@ impl std::fmt::Display for Update {
 #[cfg(test)]
 impl Into<Store> for Update {
     fn into(self) -> Store {
-        let mut store = Store::new(0);
+        let mut store = Store::new(Options::with_client_id(0));
         for (client_id, vec) in self.blocks.clients {
             let blocks = store
                 .blocks

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -18,7 +18,10 @@ use yrs::types::{
 };
 use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
-use yrs::{Array, Doc, Map, StateVector, Text, Transaction, Update, Xml, XmlElement, XmlText};
+use yrs::{
+    Array, Doc, Encoding, Map, Options, StateVector, Text, Transaction, Update, Xml, XmlElement,
+    XmlText,
+};
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
 // allocator.
@@ -74,11 +77,14 @@ impl YDoc {
     /// be assigned a randomly generated number.
     #[wasm_bindgen(constructor)]
     pub fn new(id: Option<f64>) -> Self {
-        if let Some(id) = id {
-            YDoc(Doc::with_client_id(id as u64))
+        let mut options = if let Some(id) = id {
+            Options::with_client_id(id as u64)
         } else {
-            YDoc(Doc::new())
-        }
+            Options::default()
+        };
+
+        options.encoding = Encoding::Utf16;
+        YDoc(Doc::with_options(options))
     }
 
     /// Gets globally unique identifier of this `YDoc` instance.


### PR DESCRIPTION
1. Blocks lengths are now always counted by UTF16 standard - for compatibility with Yjs.
2. Added `Doc` options with an encoding setting, that can be used to determine what kind of encoding to use (utf8 byte length, utf16 chars or utf32 chars) in order to perform `YText` offset/length related operations. This is crucial for cross-platform support - also since blocks are always computed by utf16 standard, replicating documents could have different encoding schemes and everything still should work.