### PR TITLE
Y-Py Basic Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,16 +209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
-dependencies = [
- "quote 1.0.10",
- "syn 1.0.81",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,17 +242,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "ghost"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
-dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.81",
 ]
 
 [[package]]
@@ -310,28 +289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "inventory"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0f7efb804ec95e33db9ad49e4252f049e37e8b0a4652e3cd61f7999f2eff7f"
-dependencies = [
- "ctor",
- "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
-dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.81",
 ]
 
 [[package]]
@@ -436,6 +393,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "oorandom"
@@ -578,26 +541,34 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.13.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4837b8e8e18a102c23f79d1e9a110b597ea3b684c95e874eb1ad88f8683109c3"
+checksum = "35100f9347670a566a67aa623369293703322bb9db77d99d7df7313b575ae0c8"
 dependencies = [
  "cfg-if 1.0.0",
- "ctor",
  "indoc",
- "inventory",
  "libc",
  "parking_lot",
  "paste",
+ "pyo3-build-config",
  "pyo3-macros",
  "unindent",
 ]
 
 [[package]]
-name = "pyo3-macros"
-version = "0.13.2"
+name = "pyo3-build-config"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47f2c300ceec3e58064fd5f8f5b61230f2ffd64bde4970c81fdd0563a2db1bb"
+checksum = "d12961738cacbd7f91b7c43bc25cfeeaa2698ad07a04b3be0aa88b950865738f"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0bc5215d704824dfddddc03f93cb572e1155c68b6761c37005e1c288808ea8"
 dependencies = [
  "pyo3-macros-backend",
  "quote 1.0.10",
@@ -606,23 +577,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.13.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b097e5d84fcbe3e167f400fbedd657820a375b034c78bd852050749a575d66"
+checksum = "71623fc593224afaab918aa3afcaf86ed2f43d34f6afde7f3922608f253240df"
 dependencies = [
  "proc-macro2 1.0.32",
+ "pyo3-build-config",
  "quote 1.0.10",
  "syn 1.0.81",
-]
-
-[[package]]
-name = "pythonize"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04d0a8d9bfc9a2fd5122b7e22e36a02e3e94c323212ab132ac541a064393247"
-dependencies = [
- "pyo3",
- "serde",
 ]
 
 [[package]]
@@ -1176,7 +1138,6 @@ version = "0.1.3"
 dependencies = [
  "lib0",
  "pyo3",
- "pythonize",
  "yrs",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"
@@ -98,11 +98,11 @@ dependencies = [
 
 [[package]]
 name = "console_error_panic_hook"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
 
@@ -214,8 +214,8 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
- "quote 1.0.9",
- "syn 1.0.76",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -260,16 +260,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hermit-abi"
@@ -297,9 +297,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "unindent",
 ]
 
@@ -329,9 +329,9 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "lock_api"
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-hack"
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -600,8 +600,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47f2c300ceec3e58064fd5f8f5b61230f2ffd64bde4970c81fdd0563a2db1bb"
 dependencies = [
  "pyo3-macros-backend",
- "quote 1.0.9",
- "syn 1.0.76",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -610,9 +610,9 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87b097e5d84fcbe3e167f400fbedd657820a375b034c78bd852050749a575d66"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -648,11 +648,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
 ]
 
 [[package]]
@@ -885,9 +885,9 @@ version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -929,12 +929,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
 
@@ -1046,9 +1046,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "wasm-bindgen-shared",
 ]
 
@@ -1070,7 +1070,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
- "quote 1.0.9",
+ "quote 1.0.10",
  "wasm-bindgen-macro-support",
 ]
 
@@ -1080,9 +1080,9 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
- "syn 1.0.76",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1113,8 +1113,8 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6006f79628dfeb96a86d4db51fbf1344cd7fd8408f06fc9aa3c84913a4789688"
 dependencies = [
- "proc-macro2 1.0.29",
- "quote 1.0.9",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
 ]
 
 [[package]]
@@ -1174,6 +1174,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "y-py"
 version = "0.1.3"
 dependencies = [
+ "lib0",
  "pyo3",
  "pythonize",
  "yrs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "y-py"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "lib0",
  "pyo3",

--- a/y-py/.gitignore
+++ b/y-py/.gitignore
@@ -1,0 +1,1 @@
+tests/__pycache__

--- a/y-py/Cargo.toml
+++ b/y-py/Cargo.toml
@@ -13,8 +13,7 @@ crate-type = ["cdylib"]
 [dependencies]
 yrs = { path = "../yrs" }
 lib0 = { path = "../lib0" }
-pythonize = "0.13.0"
 
 [dependencies.pyo3]
-version = "0.13.2"
+version = "0.14.5"
 features = ["extension-module"]

--- a/y-py/Cargo.toml
+++ b/y-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "y-py"
-version = "0.2"
+version = "0.2.0"
 authors = ["Pierre-Olivier Simonard <pierre.olivier.simonard@gmail.com>", "Kevin Jahns <kevin.jahns@protonmail.com>", "John Waidhofer <waidhoferj@gmail.com>"]
 edition = "2018"
 

--- a/y-py/Cargo.toml
+++ b/y-py/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 yrs = { path = "../yrs" }
+lib0 = { path = "../lib0" }
 pythonize = "0.13.0"
 
 [dependencies.pyo3]

--- a/y-py/Cargo.toml
+++ b/y-py/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "y-py"
-version = "0.1.3"
-authors = ["Pierre-Olivier Simonard <pierre.olivier.simonard@gmail.com>", "Kevin Jahns <kevin.jahns@protonmail.com>"]
+version = "0.2"
+authors = ["Pierre-Olivier Simonard <pierre.olivier.simonard@gmail.com>", "Kevin Jahns <kevin.jahns@protonmail.com>", "John Waidhofer <waidhoferj@gmail.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/y-py/src/lib.rs
+++ b/y-py/src/lib.rs
@@ -1,14 +1,18 @@
 #![feature()]
 
 use lib0::any::Any;
+use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
+use pyo3::types as pytypes;
 use pyo3::types::{PyAny, PyByteArray, PyDict};
 use pyo3::wrap_pyfunction;
+use std::cell::Ref;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use yrs;
 use yrs::block::{ItemContent, Prelim};
@@ -53,7 +57,6 @@ use yrs::{
 pub struct YDoc {
     inner: Doc,
 }
-
 
 #[pymethods]
 impl YDoc {
@@ -109,22 +112,9 @@ impl YDoc {
             let doc: *mut Doc = &mut self.inner;
             let static_txn: ManuallyDrop<Transaction<'static>> =
                 ManuallyDrop::new((*doc).transact());
-            YTransaction{inner: static_txn}
+            YTransaction { inner: static_txn }
         }
     }
-
-    /// Returns a `YText` shared data type, that's accessible for subsequent accesses using given
-    /// `name`.
-    ///
-    /// If there was no instance with this name before, it will be created and then returned.
-    ///
-    /// If there was an instance with this name, but it was of different type, it will be projected
-    /// onto `YText` instance.
-    // pub fn get_text(&mut self, name: &str) -> YText {
-    //     self.begin_transaction().get_text(name)
-    // }
-
-    
 
     /// Returns a `YMap` shared data type, that's accessible for subsequent accesses using given
     /// `name`.
@@ -166,8 +156,19 @@ impl YDoc {
     ///
     /// If there was an instance with this name, but it was of different type, it will be projected
     /// onto `YArray` instance.
-    pub fn get_array(&mut self, name: &str) -> YArray {
-        self.begin_transaction().get_array(name)
+    // pub fn get_array(&mut self, name: &str) -> YArray {
+    //     self.begin_transaction().get_array(name)
+    // }
+
+    /// Returns a `YText` shared data type, that's accessible for subsequent accesses using given
+    /// `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YText` instance.
+    pub fn get_text(&mut self, name: &str) -> YText {
+        self.begin_transaction().get_text(name)
     }
 }
 
@@ -272,7 +273,9 @@ pub fn apply_update(doc: &mut YDoc, diff: Vec<u8>) {
 /// doc.transact(txn => text.insert(txn, 0, 'hello world'))
 /// ```
 #[pyclass(unsendable)]
-pub struct YTransaction { inner: ManuallyDrop<Transaction<'static>>}
+pub struct YTransaction {
+    inner: ManuallyDrop<Transaction<'static>>,
+}
 
 impl Deref for YTransaction {
     type Target = Transaction<'static>;
@@ -303,9 +306,9 @@ impl YTransaction {
     ///
     /// If there was an instance with this name, but it was of different type, it will be projected
     /// onto `YText` instance.
-    // pub fn get_text(&mut self, name: &str) -> YText {
-    //     self.inner.get_text(name).into()
-    // }
+    pub fn get_text(&mut self, name: &str) -> YText {
+        self.inner.get_text(name).into()
+    }
 
     /// Returns a `YArray` shared data type, that's accessible for subsequent accesses using given
     /// `name`.
@@ -314,9 +317,9 @@ impl YTransaction {
     ///
     /// If there was an instance with this name, but it was of different type, it will be projected
     /// onto `YArray` instance.
-    pub fn get_array(&mut self, name: &str) -> YArray {
-        self.inner.get_array(name).into()
-    }
+    // pub fn get_array(&mut self, name: &str) -> YArray {
+    //     self.inner.get_array(name).into()
+    // }
 
     /// Returns a `YMap` shared data type, that's accessible for subsequent accesses using given
     /// `name`.
@@ -388,7 +391,7 @@ impl YTransaction {
     pub fn state_vector_v1(&self) -> Vec<u8> {
         let sv = self.inner.state_vector();
         let payload = sv.encode_v1();
-        &payload[..payload.len()]
+        payload
     }
 
     /// Encodes all updates that have happened since a given version `vector` into a compact delta
@@ -460,6 +463,24 @@ impl YTransaction {
         let update = Update::decode(&mut decoder);
         self.inner.apply_update(update)
     }
+
+    fn __enter__<'p>(slf: PyRef<'p, Self>, _py: Python<'p>) -> PyResult<PyRef<'p, Self>> {
+        println!("started");
+        Ok(slf)
+    }
+
+    fn __exit__<'p>(
+        &'p mut self,
+        _exc_type: Option<&'p PyAny>,
+        _exc_value: Option<&'p PyAny>,
+        _traceback: Option<&'p PyAny>,
+    ) -> PyResult<bool> {
+        println!("Ended");
+        self.commit();
+        // TODO: delete self as well
+        drop(self);
+        return Ok(true);
+    }
 }
 
 enum SharedType<T, P> {
@@ -493,11 +514,16 @@ impl<T, P> SharedType<T, P> {
 /// after merging all updates together). In case of Yrs conflict resolution is solved by using
 /// unique document id to determine correct and consistent ordering.
 #[pyclass(unsendable)]
-pub struct YText{ inner: RefCell<SharedType<Text, String>>}
+#[derive(Clone)]
+pub struct YText {
+    inner: Rc<RefCell<SharedType<Text, String>>>,
+}
 
 impl From<Text> for YText {
     fn from(v: Text) -> Self {
-        YText{ inner: SharedType::new(v)}
+        YText {
+            inner: Rc::new(SharedType::new(v)),
+        }
     }
 }
 
@@ -511,7 +537,9 @@ impl YText {
     /// document store and cannot be nested again: attempt to do so will result in an exception.
     #[new]
     pub fn new(init: Option<String>) -> Self {
-        YText { inner: SharedType::prelim(init.unwrap_or_default())}
+        YText {
+            inner: Rc::new(SharedType::prelim(init.unwrap_or_default())),
+        }
     }
 
     /// Returns true if this is a preliminary instance of `YText`.
@@ -539,7 +567,7 @@ impl YText {
     }
 
     /// Returns an underlying shared string stored in this data type.
-    // TODO: MAke this a native __str__ dunder function
+    // TODO: Make this a native __str__ dunder function
     pub fn to_string(&self, txn: &YTransaction) -> String {
         match &*self.inner.borrow() {
             SharedType::Integrated(v) => v.to_string(txn),
@@ -548,10 +576,10 @@ impl YText {
     }
 
     /// Returns an underlying shared string stored in this data type.
-    pub fn to_json(&self, txn: &YTransaction) -> JsValue {
+    pub fn to_json(&self, txn: &YTransaction) -> String {
         match &*self.inner.borrow() {
-            SharedType::Integrated(v) => JsValue::from(&v.to_string(txn)),
-            SharedType::Prelim(v) => JsValue::from(v),
+            SharedType::Integrated(v) => v.to_string(txn),
+            SharedType::Prelim(v) => v.clone(),
         }
     }
 
@@ -601,242 +629,238 @@ impl YText {
 /// when elements inserted one after another may interleave with other peers concurrent inserts
 /// after merging all updates together). In case of Yrs conflict resolution is solved by using
 /// unique document id to determine correct and consistent ordering.
-#[pyclass(unsendable)]
-pub struct YArray{ inner: RefCell<SharedType<Array, Vec<PyAny>>>}
+// #[pyclass(unsendable)]
+// pub struct YArray {
+//     inner: RefCell<SharedType<Array, Vec<PyAny>>>,
+// }
 
-impl From<Array> for YArray {
-    fn from(v: Array) -> Self {
-        YArray{inner: SharedType::new(v)}
-    }
-}
+// impl From<Array> for YArray {
+//     fn from(v: Array) -> Self {
+//         YArray {
+//             inner: SharedType::new(v),
+//         }
+//     }
+// }
 
-#[pymethods]
-impl YArray {
-    /// Creates a new preliminary instance of a `YArray` shared data type, with its state
-    /// initialized to provided parameter.
-    ///
-    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
-    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
-    /// document store and cannot be nested again: attempt to do so will result in an exception.
-    #[new]
-    pub fn new(init: Option<Vec<PyAny>>) -> Self {
-        YArray {inner: SharedType::prelim(init.unwrap_or_default())}
-    }
+// #[pymethods]
+// impl YArray {
+//     /// Creates a new preliminary instance of a `YArray` shared data type, with its state
+//     /// initialized to provided parameter.
+//     ///
+//     /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+//     /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+//     /// document store and cannot be nested again: attempt to do so will result in an exception.
+//     #[new]
+//     pub fn new(init: Option<Vec<PyAny>>) -> Self {
+//         YArray {
+//             inner: SharedType::prelim(init.unwrap_or_default()),
+//         }
+//     }
 
-    /// Returns true if this is a preliminary instance of `YArray`.
-    ///
-    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
-    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
-    /// document store and cannot be nested again: attempt to do so will result in an exception.
-    #[getter]
-    pub fn prelim(&self) -> bool {
-        if let SharedType::Prelim(_) = &*self.inner.borrow() {
-            true
-        } else {
-            false
-        }
-    }
+//     /// Returns true if this is a preliminary instance of `YArray`.
+//     ///
+//     /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+//     /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+//     /// document store and cannot be nested again: attempt to do so will result in an exception.
+//     #[getter]
+//     pub fn prelim(&self) -> bool {
+//         if let SharedType::Prelim(_) = &*self.inner.borrow() {
+//             true
+//         } else {
+//             false
+//         }
+//     }
 
-    /// Returns a number of elements stored within this instance of `YArray`.
-    #[getter]
-    pub fn length(&self) -> u32 {
-        match &*self.inner.borrow() {
-            SharedType::Integrated(v) => v.len(),
-            SharedType::Prelim(v) => v.len() as u32,
-        }
-    }
+//     /// Returns a number of elements stored within this instance of `YArray`.
+//     #[getter]
+//     pub fn length(&self) -> u32 {
+//         match &*self.inner.borrow() {
+//             SharedType::Integrated(v) => v.len(),
+//             SharedType::Prelim(v) => v.len() as u32,
+//         }
+//     }
 
-    /// Converts an underlying contents of this `YArray` instance into their JSON representation.
-    pub fn to_json(&self, txn: &YTransaction) -> PyDict {
-        match &*self.inner.borrow() {
-            SharedType::Integrated(v) => any_into_js(v.to_json(txn)),
-            SharedType::Prelim(v) => {
-                let array = js_sys::Array::new();
-                for js in v.iter() {
-                    array.push(js);
-                }
-                array.into()
-            }
-        }
-    }
+//     /// Converts an underlying contents of this `YArray` instance into their JSON representation.
+//     pub fn to_json(&self, txn: &YTransaction) -> PyDict {
+//         match &*self.inner.borrow() {
+//             SharedType::Integrated(v) => any_into_py(v.to_json(txn)),
+//             SharedType::Prelim(v) => v.into(),
+//         }
+//     }
 
-    /// Inserts a given range of `items` into this `YArray` instance, starting at given `index`.
-    pub fn insert(&self, txn: &mut YTransaction, index: u32, items: Vec<JsValue>) {
-        let mut j = index;
-        match &mut *self.inner.borrow_mut() {
-            SharedType::Integrated(array) => {
-                insert_at(array, txn, index, items);
-            }
-            SharedType::Prelim(vec) => {
-                for js in items {
-                    vec.insert(j as usize, js);
-                    j += 1;
-                }
-            }
-        }
-    }
+//     /// Inserts a given range of `items` into this `YArray` instance, starting at given `index`.
+//     pub fn insert(&self, txn: &mut YTransaction, index: u32, items: Vec<PyAny>) {
+//         let mut j = index;
+//         match &mut *self.inner.borrow_mut() {
+//             SharedType::Integrated(array) => {
+//                 insert_at(array, txn, index, items);
+//             }
+//             SharedType::Prelim(vec) => {
+//                 for el in items {
+//                     vec.insert(j as usize, el);
+//                     j += 1;
+//                 }
+//             }
+//         }
+//     }
 
-    /// Appends a range of `items` at the end of this `YArray` instance.
-    pub fn push(&self, txn: &mut YTransaction, items: Vec<JsValue>) {
-        let index = self.length();
-        self.insert(txn, index, items);
-    }
+//     /// Appends a range of `items` at the end of this `YArray` instance.
+//     pub fn push(&self, txn: &mut YTransaction, items: Vec<PyAny>) {
+//         let index = self.length();
+//         self.insert(txn, index, items);
+//     }
 
-    /// Deletes a range of items of given `length` from current `YArray` instance,
-    /// starting from given `index`.
-    pub fn delete(&self, txn: &mut YTransaction, index: u32, length: u32) {
-        match &mut *self.inner.borrow_mut() {
-            SharedType::Integrated(v) => v.remove_range(txn, index, length),
-            SharedType::Prelim(v) => {
-                v.drain((index as usize)..(index + length) as usize);
-            }
-        }
-    }
+//     /// Deletes a range of items of given `length` from current `YArray` instance,
+//     /// starting from given `index`.
+//     pub fn delete(&self, txn: &mut YTransaction, index: u32, length: u32) {
+//         match &mut *self.inner.borrow_mut() {
+//             SharedType::Integrated(v) => v.remove_range(txn, index, length),
+//             SharedType::Prelim(v) => {
+//                 v.drain((index as usize)..(index + length) as usize);
+//             }
+//         }
+//     }
 
-    /// Returns an element stored under given `index`.
-    pub fn get(&self, txn: &YTransaction, index: u32) -> Result<JsValue, JsValue> {
-        match &*self.inner.borrow() {
-            SharedType::Integrated(v) => {
-                if let Some(value) = v.get(txn, index) {
-                    Ok(value_into_js(value))
-                } else {
-                    Err(JsValue::from("Index outside the bounds of an YArray"))
-                }
-            }
-            SharedType::Prelim(v) => {
-                if let Some(value) = v.get(index as usize) {
-                    Ok(value.clone())
-                } else {
-                    Err(JsValue::from("Index outside the bounds of an YArray"))
-                }
-            }
-        }
-    }
+//     /// Returns an element stored under given `index`.
+//     pub fn get(&self, txn: &YTransaction, index: u32) -> PyResult<PyAny> {
+//         match &*self.inner.borrow() {
+//             SharedType::Integrated(v) => {
+//                 if let Some(value) = v.get(txn, index) {
+//                     Ok(value_into_py(value))
+//                 } else {
+//                     Err(PyIndexError::new_err(
+//                         "Index outside the bounds of an YArray",
+//                     ))
+//                 }
+//             }
+//             SharedType::Prelim(v) => {
+//                 if let Some(value) = v.get(index as usize) {
+//                     Ok(value.clone())
+//                 } else {
+//                     Err(PyIndexError::new_err(
+//                         "Index outside the bounds of an YArray",
+//                     ))
+//                 }
+//             }
+//         }
+//     }
 
-    /// Returns an iterator that can be used to traverse over the values stored withing this
-    /// instance of `YArray`.
-    ///
-    /// Example:
-    ///
-    /// ```javascript
-    /// import YDoc from 'ywasm'
-    ///
-    /// /// document on machine A
-    /// const doc = new YDoc()
-    /// const array = doc.getArray('name')
-    /// const txn = doc.beginTransaction()
-    /// try {
-    ///     array.push(txn, ['hello', 'world'])
-    ///     for (let item of array.values(txn)) {
-    ///         console.log(item)
-    ///     }
-    /// } finally {
-    ///     txn.free()
-    /// }
-    /// ```
-    pub fn values(&self, txn: &YTransaction) -> JsValue {
-        to_iter(match &*self.inner.borrow() {
-            SharedType::Integrated(v) => unsafe {
-                let this: *const Array = v;
-                let tx: *const Transaction<'static> = txn.0.deref();
-                let static_iter: ManuallyDrop<ArrayIter<'static, 'static>> =
-                    ManuallyDrop::new((*this).iter(tx.as_ref().unwrap()));
-                YArrayIterator(static_iter).into()
-            },
-            SharedType::Prelim(v) => unsafe {
-                let this: *const Vec<JsValue> = v;
-                let static_iter: ManuallyDrop<std::slice::Iter<'static, JsValue>> =
-                    ManuallyDrop::new((*this).iter());
-                PrelimArrayIterator(static_iter).into()
-            },
-        })
-    }
-}
+//     /// Returns an iterator that can be used to traverse over the values stored withing this
+//     /// instance of `YArray`.
+//     ///
+//     /// Example:
+//     ///
+//     /// ```javascript
+//     /// import YDoc from 'ywasm'
+//     ///
+//     /// /// document on machine A
+//     /// const doc = new YDoc()
+//     /// const array = doc.getArray('name')
+//     /// const txn = doc.beginTransaction()
+//     /// try {
+//     ///     array.push(txn, ['hello', 'world'])
+//     ///     for (let item of array.values(txn)) {
+//     ///         console.log(item)
+//     ///     }
+//     /// } finally {
+//     ///     txn.free()
+//     /// }
+//     /// ```
+//     pub fn values(&self, txn: &YTransaction) -> PyAny {
+//         match &*self.inner.borrow() {
+//             SharedType::Integrated(v) => unsafe {
+//                 let this: *const Array = v;
+//                 let tx: *const Transaction<'static> = txn.0.deref();
+//                 let static_iter: ManuallyDrop<ArrayIter<'static, 'static>> =
+//                     ManuallyDrop::new((*this).iter(tx.as_ref().unwrap()));
+//                 YArrayIterator {inner: static_iter}.into()
+//             },
+//             SharedType::Prelim(v) => unsafe {
+//                 let this: *const Vec<PyAny> = v;
+//                 let static_iter: ManuallyDrop<std::slice::Iter<'static, PyAny>> =
+//                     ManuallyDrop::new((*this).iter());
+//                 PrelimArrayIterator {inner : static_iter}.into()
+//             },
+//         }
+//     }
+// }
 
-fn to_iter(iterator: JsValue) -> JsValue {
-    let iter = js_sys::Object::new();
-    let symbol_iter = js_sys::Symbol::iterator();
-    let cb = Closure::once_into_js(move || iterator);
-    js_sys::Reflect::set(&iter, &symbol_iter.into(), &cb).unwrap();
-    iter.into()
-}
+// #[pyclass(unsendable)]
+// pub struct IteratorNext {
+//     value: PyAny,
+//     done: bool,
+// }
 
-#[pyclass]
-pub struct IteratorNext {
-    value: JsValue,
-    done: bool,
-}
+// #[pymethods]
+// impl IteratorNext {
+//     #[new]
+//     fn new(value: PyAny) -> Self {
+//         IteratorNext { done: false, value }
+//     }
 
-#[pymethods]
-impl IteratorNext {
-    #[new]
-    fn new(value: JsValue) -> Self {
-        IteratorNext { done: false, value }
-    }
+//     #[staticmethod] // TODO: Check if this is really static
+//     fn finished() -> Self {
+//         IteratorNext {
+//             done: true,
+//             value: PyAny::undefined(),
+//         }
+//     }
 
-    #[staticmethod] // TODO: Check if this is really static
-    fn finished() -> Self {
-        IteratorNext {
-            done: true,
-            value: JsValue::undefined(),
-        }
-    }
+//     #[getter]
+//     pub fn value(&self) -> PyAny {
+//         self.value.clone()
+//     }
 
-    #[getter]
-    pub fn value(&self) -> JsValue {
-        self.value.clone()
-    }
+//     #[getter]
+//     pub fn done(&self) -> bool {
+//         self.done
+//     }
+// }
 
-    #[getter]
-    pub fn done(&self) -> bool {
-        self.done
-    }
-}
+// impl From<Option<Value>> for IteratorNext {
+//     fn from(v: Option<Value>) -> Self {
+//         match v {
+//             None => IteratorNext::finished(),
+//             Some(v) => IteratorNext::new(value_into_py(v)),
+//         }
+//     }
+// }
 
-impl From<Option<Value>> for IteratorNext {
-    fn from(v: Option<Value>) -> Self {
-        match v {
-            None => IteratorNext::finished(),
-            Some(v) => IteratorNext::new(value_into_js(v)),
-        }
-    }
-}
+// #[pyclass(unsendable)]
+// pub struct YArrayIterator{ inner: ManuallyDrop<ArrayIter<'static, 'static>>};
 
-#[pyclass]
-pub struct YArrayIterator(ManuallyDrop<ArrayIter<'static, 'static>>);
+// impl Drop for YArrayIterator {
+//     fn drop(&mut self) {
+//         unsafe { ManuallyDrop::drop(&mut self.inner) }
+//     }
+// }
 
-impl Drop for YArrayIterator {
-    fn drop(&mut self) {
-        unsafe { ManuallyDrop::drop(&mut self.inner) }
-    }
-}
+// #[pymethods]
+// impl YArrayIterator {
+//     pub fn next(&mut self) -> IteratorNext {
+//         self.inner.next().into()
+//     }
+// }
 
-#[pymethods]
-impl YArrayIterator {
-    pub fn next(&mut self) -> IteratorNext {
-        self.inner.next().into()
-    }
-}
+// #[pyclass(unsendable)]
+// pub struct PrelimArrayIterator{inner: ManuallyDrop<std::slice::Iter<'static, PyAny>>};
 
-#[pyclass]
-pub struct PrelimArrayIterator(ManuallyDrop<std::slice::Iter<'static, JsValue>>);
+// impl Drop for PrelimArrayIterator {
+//     fn drop(&mut self) {
+//         unsafe { ManuallyDrop::drop(&mut self.inner) }
+//     }
+// }
 
-impl Drop for PrelimArrayIterator {
-    fn drop(&mut self) {
-        unsafe { ManuallyDrop::drop(&mut self.inner) }
-    }
-}
-
-#[pymethods]
-impl PrelimArrayIterator {
-    pub fn next(&mut self) -> IteratorNext {
-        if let Some(js) = self.inner.next() {
-            IteratorNext::new(js.clone())
-        } else {
-            IteratorNext::finished()
-        }
-    }
-}
+// #[pymethods]
+// impl PrelimArrayIterator {
+//     pub fn next(&mut self) -> IteratorNext {
+//         if let Some(js) = self.inner.next() {
+//             IteratorNext::new(js.clone())
+//         } else {
+//             IteratorNext::finished()
+//         }
+//     }
+// }
 
 /// Collection used to store key-value entries in an unordered manner. Keys are always represented
 /// as UTF-8 strings. Values can be any value type supported by Yrs: JSON-like primitives as well as
@@ -846,560 +870,564 @@ impl PrelimArrayIterator {
 /// updates are automatically overridden and discarded by newer ones, while concurrent updates made
 /// by different peers are resolved into a single value using document id seniority to establish
 /// order.
-#[pyclass]
-pub struct YMap(RefCell<SharedType<Map, HashMap<String, JsValue>>>);
+// #[pyclass]
+// pub struct YMap(RefCell<SharedType<Map, HashMap<String, PyAny>>>);
 
-impl From<Map> for YMap {
-    fn from(v: Map) -> Self {
-        YMap(SharedType::new(v))
-    }
+// impl From<Map> for YMap {
+//     fn from(v: Map) -> Self {
+//         YMap(SharedType::new(v))
+//     }
+// }
+
+// #[pymethods]
+// impl YMap {
+//     /// Creates a new preliminary instance of a `YMap` shared data type, with its state
+//     /// initialized to provided parameter.
+//     ///
+//     /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+//     /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+//     /// document store and cannot be nested again: attempt to do so will result in an exception.
+//     #[new]
+//     pub fn new(init: Option<js_sys::Object>) -> Self {
+//         let map = if let Some(object) = init {
+//             let mut map = HashMap::new();
+//             let entries = js_sys::Object::entries(&object);
+//             for tuple in entries.iter() {
+//                 let tuple = js_sys::Array::from(&tuple);
+//                 let key = tuple.get(0).as_string().unwrap();
+//                 let value = tuple.get(1);
+//                 map.insert(key, value);
+//             }
+//             map
+//         } else {
+//             HashMap::new()
+//         };
+//         YMap(SharedType::prelim(map))
+//     }
+
+//     /// Returns true if this is a preliminary instance of `YMap`.
+//     ///
+//     /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+//     /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+//     /// document store and cannot be nested again: attempt to do so will result in an exception.
+//     #[getter]
+//     pub fn prelim(&self) -> bool {
+//         if let SharedType::Prelim(_) = &*self.inner.borrow() {
+//             true
+//         } else {
+//             false
+//         }
+//     }
+
+//     /// Returns a number of entries stored within this instance of `YMap`.
+//     pub fn length(&self, txn: &YTransaction) -> u32 {
+//         match &*self.inner.borrow() {
+//             SharedType::Integrated(v) => v.len(txn),
+//             SharedType::Prelim(v) => v.len() as u32,
+//         }
+//     }
+
+//     /// Converts contents of this `YMap` instance into a JSON representation.
+//     pub fn to_json(&self, txn: &YTransaction) -> PyAny {
+//         match &*self.inner.borrow() {
+//             SharedType::Integrated(v) => any_into_py(v.to_json(txn)),
+//             SharedType::Prelim(v) => {
+//                 let map = js_sys::Object::new();
+//                 for (k, v) in v.iter() {
+//                     js_sys::Reflect::set(&map, &k.into(), v).unwrap();
+//                 }
+//                 map.into()
+//             }
+//         }
+//     }
+
+//     /// Sets a given `key`-`value` entry within this instance of `YMap`. If another entry was
+//     /// already stored under given `key`, it will be overridden with new `value`.
+//     pub fn set(&self, txn: &mut YTransaction, key: &str, value: PyAny) {
+//         match &mut *self.inner.borrow_mut() {
+//             SharedType::Integrated(v) => {
+//                 v.insert(txn, key.to_string(), PyAnyWrapper(value));
+//             }
+//             SharedType::Prelim(v) => {
+//                 v.insert(key.to_string(), value);
+//             }
+//         }
+//     }
+
+//     /// Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.
+//     pub fn delete(&mut self, txn: &mut YTransaction, key: &str) {
+//         match &mut *self.inner.borrow_mut() {
+//             SharedType::Integrated(v) => {
+//                 v.remove(txn, key);
+//             }
+//             SharedType::Prelim(v) => {
+//                 v.remove(key);
+//             }
+//         }
+//     }
+
+//     /// Returns value of an entry stored under given `key` within this instance of `YMap`,
+//     /// or `undefined` if no such entry existed.
+//     pub fn get(&self, txn: &mut YTransaction, key: &str) -> PyAny {
+//         match &*self.inner.borrow() {
+//             SharedType::Integrated(v) => {
+//                 if let Some(value) = v.get(txn, key) {
+//                     value_into_py(value)
+//                 } else {
+//                     PyAny::undefined()
+//                 }
+//             }
+//             SharedType::Prelim(v) => {
+//                 if let Some(value) = v.get(key) {
+//                     value.clone()
+//                 } else {
+//                     PyAny::undefined()
+//                 }
+//             }
+//         }
+//     }
+
+//     /// Returns an iterator that can be used to traverse over all entries stored within this
+//     /// instance of `YMap`. Order of entry is not specified.
+//     ///
+//     /// Example:
+//     ///
+//     /// ```javascript
+//     /// import YDoc from 'ywasm'
+//     ///
+//     /// /// document on machine A
+//     /// const doc = new YDoc()
+//     /// const map = doc.getMap('name')
+//     /// const txn = doc.beginTransaction()
+//     /// try {
+//     ///     map.set(txn, 'key1', 'value1')
+//     ///     map.set(txn, 'key2', true)
+//     ///
+//     ///     for (let [key, value] of map.entries(txn)) {
+//     ///         console.log(key, value)
+//     ///     }
+//     /// } finally {
+//     ///     txn.free()
+//     /// }
+//     /// ```
+//     pub fn entries(&self, txn: &mut YTransaction) -> PyAny {
+//         to_iter(match &*self.inner.borrow() {
+//             SharedType::Integrated(v) => unsafe {
+//                 let this: *const Map = v;
+//                 let tx: *const Transaction<'static> = txn.0.deref();
+//                 let static_iter: ManuallyDrop<MapIter<'static, 'static>> =
+//                     ManuallyDrop::new((*this).iter(tx.as_ref().unwrap()));
+//                 YMapIterator(static_iter).into()
+//             },
+//             SharedType::Prelim(v) => unsafe {
+//                 let this: *const HashMap<String, PyAny> = v;
+//                 let static_iter: ManuallyDrop<
+//                     std::collections::hash_map::Iter<'static, String, PyAny>,
+//                 > = ManuallyDrop::new((*this).iter());
+//                 PrelimMapIterator(static_iter).into()
+//             },
+//         })
+//     }
+// }
+
+// #[pyclass(unsendable)]
+// pub struct YMapIterator {
+//     inner: ManuallyDrop<MapIter<'static, 'static>>,
+// }
+
+// impl Deref for YMapIterator {
+//     fn deref(self) {
+//         self.inner.deref();
+//     }
+// }
+
+// impl Drop for YMapIterator {
+//     fn drop(&mut self) {
+//         unsafe { ManuallyDrop::drop(&mut self.inner) }
+//     }
+// }
+
+// impl<'a> From<Option<(&'a String, Value)>> for IteratorNext {
+//     fn from(entry: Option<(&'a String, Value)>) -> Self {
+//         match entry {
+//             None => IteratorNext::finished(),
+//             Some((k, v)) => {
+//                 let tuple = js_sys::Array::new_with_length(2);
+//                 tuple.set(0, PyAny::from(k));
+//                 tuple.set(1, value_into_py(v));
+//                 IteratorNext::new(tuple.into())
+//             }
+//         }
+//     }
+// }
+
+// #[pymethods]
+// impl YMapIterator {
+//     pub fn next(&mut self) -> IteratorNext {
+//         self.inner.next().into()
+//     }
+// }
+
+// #[pyclass]
+// pub struct PrelimMapIterator(
+//     ManuallyDrop<std::collections::hash_map::Iter<'static, String, PyAny>>,
+// );
+
+// impl Drop for PrelimMapIterator {
+//     fn drop(&mut self) {
+//         unsafe { ManuallyDrop::drop(&mut self.inner) }
+//     }
+// }
+
+// #[pymethods]
+// impl PrelimMapIterator {
+//     pub fn next(&mut self) -> IteratorNext {
+//         if let Some((key, value)) = self.inner.next() {
+//             let array = js_sys::Array::new_with_length(2);
+//             array.push(&PyAny::from(key));
+//             array.push(value);
+//             IteratorNext::new(array.into())
+//         } else {
+//             IteratorNext::finished()
+//         }
+//     }
+// }
+
+// /// XML element data type. It represents an XML node, which can contain key-value attributes
+// /// (interpreted as strings) as well as other nested XML elements or rich text (represented by
+// /// `YXmlText` type).
+// ///
+// /// In terms of conflict resolution, `YXmlElement` uses following rules:
+// ///
+// /// - Attribute updates use logical last-write-wins principle, meaning the past updates are
+// ///   automatically overridden and discarded by newer ones, while concurrent updates made by
+// ///   different peers are resolved into a single value using document id seniority to establish
+// ///   an order.
+// /// - Child node insertion uses sequencing rules from other Yrs collections - elements are inserted
+// ///   using interleave-resistant algorithm, where order of concurrent inserts at the same index
+// ///   is established using peer's document id seniority.
+// #[pyclass]
+// pub struct YXmlElement(XmlElement);
+
+// #[pymethods]
+// impl YXmlElement {
+//     /// Returns a tag name of this XML node.
+//     #[getter]
+//     pub fn name(&self) -> String {
+//         self.inner.tag().to_string()
+//     }
+
+//     /// Returns a number of child XML nodes stored within this `YXMlElement` instance.
+//     pub fn length(&self, txn: &YTransaction) -> u32 {
+//         self.inner.len(txn)
+//     }
+
+//     /// Inserts a new instance of `YXmlElement` as a child of this XML node and returns it.
+//     pub fn insert_xml_element(
+//         &self,
+//         txn: &mut YTransaction,
+//         index: u32,
+//         name: &str,
+//     ) -> YXmlElement {
+//         YXmlElement(self.inner.insert_elem(txn, index, name))
+//     }
+
+//     /// Inserts a new instance of `YXmlText` as a child of this XML node and returns it.
+//     pub fn insert_xml_text(&self, txn: &mut YTransaction, index: u32) -> YXmlText {
+//         YXmlText(self.inner.insert_text(txn, index))
+//     }
+
+//     /// Removes a range of children XML nodes from this `YXmlElement` instance,
+//     /// starting at given `index`.
+
+//     pub fn delete(&self, txn: &mut YTransaction, index: u32, length: u32) {
+//         self.inner.remove_range(txn, index, length)
+//     }
+
+//     /// Appends a new instance of `YXmlElement` as the last child of this XML node and returns it.
+//     pub fn push_xml_element(&self, txn: &mut YTransaction, name: &str) -> YXmlElement {
+//         YXmlElement(self.inner.push_elem_back(txn, name))
+//     }
+
+//     /// Appends a new instance of `YXmlText` as the last child of this XML node and returns it.
+//     pub fn push_xml_text(&self, txn: &mut YTransaction) -> YXmlText {
+//         YXmlText(self.inner.push_text_back(txn))
+//     }
+
+//     /// Returns a first child of this XML node.
+//     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node has not children.
+//     pub fn first_child(&self, txn: &YTransaction) -> PyAny {
+//         if let Some(xml) = self.inner.first_child(txn) {
+//             xml_into_js(xml)
+//         } else {
+//             PyAny::undefined()
+//         }
+//     }
+
+//     /// Returns a next XML sibling node of this XMl node.
+//     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a last child of
+//     /// parent XML node.
+//     pub fn next_sibling(&self, txn: &YTransaction) -> PyAny {
+//         if let Some(xml) = self.inner.next_sibling(txn) {
+//             xml_into_js(xml)
+//         } else {
+//             PyAny::undefined()
+//         }
+//     }
+
+//     /// Returns a previous XML sibling node of this XMl node.
+//     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a first child
+//     /// of parent XML node.
+//     pub fn prev_sibling(&self, txn: &YTransaction) -> PyAny {
+//         if let Some(xml) = self.inner.prev_sibling(txn) {
+//             xml_into_js(xml)
+//         } else {
+//             PyAny::undefined()
+//         }
+//     }
+
+//     /// Returns a parent `YXmlElement` node or `undefined` if current node has no parent assigned.
+//     pub fn parent(&self, txn: &YTransaction) -> PyAny {
+//         if let Some(xml) = self.inner.parent(txn) {
+//             xml_into_js(Xml::Element(xml))
+//         } else {
+//             PyAny::undefined()
+//         }
+//     }
+
+//     /// Returns a string representation of this XML node.
+//     pub fn to_string(&self, txn: &YTransaction) -> String {
+//         self.inner.to_string(txn)
+//     }
+
+//     /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
+//     /// `name` already existed on that node, its value with be overridden with a provided one.
+//     pub fn set_attribute(&self, txn: &mut YTransaction, name: &str, value: &str) {
+//         self.inner.insert_attribute(txn, name, value)
+//     }
+
+//     /// Returns a value of an attribute given its `name`. If no attribute with such name existed,
+//     /// `null` will be returned.
+//     pub fn get_attribute(&self, txn: &YTransaction, name: &str) -> Option<String> {
+//         self.inner.get_attribute(txn, name)
+//     }
+
+//     /// Removes an attribute from this XML node, given its `name`.
+
+//     pub fn remove_attribute(&self, txn: &mut YTransaction, name: &str) {
+//         self.inner.remove_attribute(txn, name);
+//     }
+
+//     /// Returns an iterator that enables to traverse over all attributes of this XML node in
+//     /// unspecified order.
+
+//     pub fn attributes(&self, txn: &YTransaction) -> PyAny {
+//         to_iter(unsafe {
+//             let this: *const XmlElement = &self.inner;
+//             let tx: *const Transaction<'static> = txn.0.deref();
+//             let static_iter: ManuallyDrop<Attributes<'static, 'static>> =
+//                 ManuallyDrop::new((*this).attributes(tx.as_ref().unwrap()));
+//             YXmlAttributes(static_iter).into()
+//         })
+//     }
+
+//     /// Returns an iterator that enables a deep traversal of this XML node - starting from first
+//     /// child over this XML node successors using depth-first strategy.
+
+//     pub fn tree_walker(&self, txn: &YTransaction) -> PyAny {
+//         to_iter(unsafe {
+//             let this: *const XmlElement = &self.inner;
+//             let tx: *const Transaction<'static> = txn.0.deref();
+//             let static_iter: ManuallyDrop<TreeWalker<'static, 'static>> =
+//                 ManuallyDrop::new((*this).successors(tx.as_ref().unwrap()));
+//             YXmlTreeWalker(static_iter).into()
+//         })
+//     }
+// }
+
+// #[pyclass]
+// pub struct YXmlAttributes(ManuallyDrop<Attributes<'static, 'static>>);
+
+// impl Drop for YXmlAttributes {
+//     fn drop(&mut self) {
+//         unsafe { ManuallyDrop::drop(&mut self.inner) }
+//     }
+// }
+
+// impl<'a> From<Option<(&'a str, String)>> for IteratorNext {
+//     fn from(o: Option<(&'a str, String)>) -> Self {
+//         match o {
+//             None => IteratorNext::finished(),
+//             Some((name, value)) => {
+//                 let tuple = js_sys::Array::new_with_length(2);
+//                 tuple.set(0, PyAny::from_str(name));
+//                 tuple.set(1, PyAny::from(&value));
+//                 IteratorNext::new(tuple.into())
+//             }
+//         }
+//     }
+// }
+
+// #[pymethods]
+// impl YXmlAttributes {
+//     pub fn next(&mut self) -> IteratorNext {
+//         self.inner.next().into()
+//     }
+// }
+
+// #[pyclass]
+// pub struct YXmlTreeWalker(ManuallyDrop<TreeWalker<'static, 'static>>);
+
+// impl Drop for YXmlTreeWalker {
+//     fn drop(&mut self) {
+//         unsafe { ManuallyDrop::drop(&mut self.inner) }
+//     }
+// }
+
+// #[pymethods]
+// impl YXmlTreeWalker {
+//     pub fn next(&mut self) -> IteratorNext {
+//         if let Some(xml) = self.inner.next() {
+//             let js_val = xml_into_js(xml);
+//             IteratorNext::new(js_val)
+//         } else {
+//             IteratorNext::finished()
+//         }
+//     }
+// }
+
+// /// A shared data type used for collaborative text editing, that can be used in a context of
+// /// `YXmlElement` nodee. It enables multiple users to add and remove chunks of text in efficient
+// /// manner. This type is internally represented as a mutable double-linked list of text chunks
+// /// - an optimization occurs during `YTransaction.commit`, which allows to squash multiple
+// /// consecutively inserted characters together as a single chunk of text even between transaction
+// /// boundaries in order to preserve more efficient memory model.
+// ///
+// /// Just like `YXmlElement`, `YXmlText` can be marked with extra metadata in form of attributes.
+// ///
+// /// `YXmlText` structure internally uses UTF-8 encoding and its length is described in a number of
+// /// bytes rather than individual characters (a single UTF-8 code point can consist of many bytes).
+// ///
+// /// Like all Yrs shared data types, `YXmlText` is resistant to the problem of interleaving (situation
+// /// when characters inserted one after another may interleave with other peers concurrent inserts
+// /// after merging all updates together). In case of Yrs conflict resolution is solved by using
+// /// unique document id to determine correct and consistent ordering.
+// #[pyclass]
+// pub struct YXmlText {
+//     inner: XmlText,
+// }
+
+// #[pymethods]
+// impl YXmlText {
+//     /// Returns length of an underlying string stored in this `YXmlText` instance,
+//     /// understood as a number of UTF-8 encoded bytes.
+//     #[getter]
+//     pub fn length(&self) -> u32 {
+//         self.inner.len()
+//     }
+
+//     /// Inserts a given `chunk` of text into this `YXmlText` instance, starting at a given `index`.
+
+//     pub fn insert(&self, txn: &mut YTransaction, index: i32, chunk: &str) {
+//         self.inner.insert(txn, index as u32, chunk)
+//     }
+
+//     /// Appends a given `chunk` of text at the end of `YXmlText` instance.
+
+//     pub fn push(&self, txn: &mut YTransaction, chunk: &str) {
+//         self.inner.push(txn, chunk)
+//     }
+
+//     /// Deletes a specified range of of characters, starting at a given `index`.
+//     /// Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
+
+//     pub fn delete(&self, txn: &mut YTransaction, index: u32, length: u32) {
+//         self.inner.remove_range(txn, index, length)
+//     }
+
+//     /// Returns a next XML sibling node of this XMl node.
+//     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a last child of
+//     /// parent XML node.
+
+//     pub fn next_sibling(&self, txn: &YTransaction) -> PyAny {
+//         if let Some(xml) = self.inner.next_sibling(txn) {
+//             xml_into_js(xml)
+//         } else {
+//             PyAny::undefined()
+//         }
+//     }
+
+//     /// Returns a previous XML sibling node of this XMl node.
+//     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a first child
+//     /// of parent XML node.
+
+//     pub fn prev_sibling(&self, txn: &YTransaction) -> PyAny {
+//         if let Some(xml) = self.inner.prev_sibling(txn) {
+//             xml_into_js(xml)
+//         } else {
+//             PyAny::undefined()
+//         }
+//     }
+
+//     /// Returns a parent `YXmlElement` node or `undefined` if current node has no parent assigned.
+
+//     pub fn parent(&self, txn: &YTransaction) -> PyAny {
+//         if let Some(xml) = self.inner.parent(txn) {
+//             xml_into_js(Xml::Element(xml))
+//         } else {
+//             PyAny::undefined()
+//         }
+//     }
+
+//     /// Returns an underlying string stored in this `YXmlText` instance.
+
+//     pub fn to_string(&self, txn: &YTransaction) -> String {
+//         self.inner.to_string(txn)
+//     }
+
+//     /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
+//     /// `name` already existed on that node, its value with be overridden with a provided one.
+
+//     pub fn set_attribute(&self, txn: &mut YTransaction, name: &str, value: &str) {
+//         self.inner.insert_attribute(txn, name, value);
+//     }
+
+//     /// Returns a value of an attribute given its `name`. If no attribute with such name existed,
+//     /// `null` will be returned.
+
+//     pub fn get_attribute(&self, txn: &YTransaction, name: &str) -> Option<String> {
+//         self.inner.get_attribute(txn, name)
+//     }
+
+//     /// Removes an attribute from this XML node, given its `name`.
+
+//     pub fn remove_attribute(&self, txn: &mut YTransaction, name: &str) {
+//         self.inner.remove_attribute(txn, name);
+//     }
+
+//     /// Returns an iterator that enables to traverse over all attributes of this XML node in
+//     /// unspecified order.
+
+//     pub fn attributes(&self, txn: &YTransaction) -> YXmlAttributes {
+//         unsafe {
+//             let this: *const XmlText = &self.inner;
+//             let tx: *const Transaction<'static> = txn.0.deref();
+//             let static_iter: ManuallyDrop<Attributes<'static, 'static>> =
+//                 ManuallyDrop::new((*this).attributes(tx.as_ref().unwrap()));
+//             YXmlAttributes(static_iter)
+//         }
+//     }
+// }
+
+struct PyAnyWrapper {
+    inner: PyAny,
 }
 
-#[pymethods]
-impl YMap {
-    /// Creates a new preliminary instance of a `YMap` shared data type, with its state
-    /// initialized to provided parameter.
-    ///
-    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
-    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
-    /// document store and cannot be nested again: attempt to do so will result in an exception.
-    #[new]
-    pub fn new(init: Option<js_sys::Object>) -> Self {
-        let map = if let Some(object) = init {
-            let mut map = HashMap::new();
-            let entries = js_sys::Object::entries(&object);
-            for tuple in entries.iter() {
-                let tuple = js_sys::Array::from(&tuple);
-                let key = tuple.get(0).as_string().unwrap();
-                let value = tuple.get(1);
-                map.insert(key, value);
-            }
-            map
-        } else {
-            HashMap::new()
-        };
-        YMap(SharedType::prelim(map))
-    }
-
-    /// Returns true if this is a preliminary instance of `YMap`.
-    ///
-    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
-    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
-    /// document store and cannot be nested again: attempt to do so will result in an exception.
-    #[getter]
-    pub fn prelim(&self) -> bool {
-        if let SharedType::Prelim(_) = &*self.inner.borrow() {
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Returns a number of entries stored within this instance of `YMap`.
-    pub fn length(&self, txn: &YTransaction) -> u32 {
-        match &*self.inner.borrow() {
-            SharedType::Integrated(v) => v.len(txn),
-            SharedType::Prelim(v) => v.len() as u32,
-        }
-    }
-
-    /// Converts contents of this `YMap` instance into a JSON representation.
-    pub fn to_json(&self, txn: &YTransaction) -> JsValue {
-        match &*self.inner.borrow() {
-            SharedType::Integrated(v) => any_into_js(v.to_json(txn)),
-            SharedType::Prelim(v) => {
-                let map = js_sys::Object::new();
-                for (k, v) in v.iter() {
-                    js_sys::Reflect::set(&map, &k.into(), v).unwrap();
-                }
-                map.into()
-            }
-        }
-    }
-
-    /// Sets a given `key`-`value` entry within this instance of `YMap`. If another entry was
-    /// already stored under given `key`, it will be overridden with new `value`.
-    pub fn set(&self, txn: &mut YTransaction, key: &str, value: JsValue) {
-        match &mut *self.inner.borrow_mut() {
-            SharedType::Integrated(v) => {
-                v.insert(txn, key.to_string(), JsValueWrapper(value));
-            }
-            SharedType::Prelim(v) => {
-                v.insert(key.to_string(), value);
-            }
-        }
-    }
-
-    /// Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.
-    pub fn delete(&mut self, txn: &mut YTransaction, key: &str) {
-        match &mut *self.inner.borrow_mut() {
-            SharedType::Integrated(v) => {
-                v.remove(txn, key);
-            }
-            SharedType::Prelim(v) => {
-                v.remove(key);
-            }
-        }
-    }
-
-    /// Returns value of an entry stored under given `key` within this instance of `YMap`,
-    /// or `undefined` if no such entry existed.
-    pub fn get(&self, txn: &mut YTransaction, key: &str) -> JsValue {
-        match &*self.inner.borrow() {
-            SharedType::Integrated(v) => {
-                if let Some(value) = v.get(txn, key) {
-                    value_into_js(value)
-                } else {
-                    JsValue::undefined()
-                }
-            }
-            SharedType::Prelim(v) => {
-                if let Some(value) = v.get(key) {
-                    value.clone()
-                } else {
-                    JsValue::undefined()
-                }
-            }
-        }
-    }
-
-    /// Returns an iterator that can be used to traverse over all entries stored within this
-    /// instance of `YMap`. Order of entry is not specified.
-    ///
-    /// Example:
-    ///
-    /// ```javascript
-    /// import YDoc from 'ywasm'
-    ///
-    /// /// document on machine A
-    /// const doc = new YDoc()
-    /// const map = doc.getMap('name')
-    /// const txn = doc.beginTransaction()
-    /// try {
-    ///     map.set(txn, 'key1', 'value1')
-    ///     map.set(txn, 'key2', true)
-    ///
-    ///     for (let [key, value] of map.entries(txn)) {
-    ///         console.log(key, value)
-    ///     }
-    /// } finally {
-    ///     txn.free()
-    /// }
-    /// ```
-    pub fn entries(&self, txn: &mut YTransaction) -> JsValue {
-        to_iter(match &*self.inner.borrow() {
-            SharedType::Integrated(v) => unsafe {
-                let this: *const Map = v;
-                let tx: *const Transaction<'static> = txn.0.deref();
-                let static_iter: ManuallyDrop<MapIter<'static, 'static>> =
-                    ManuallyDrop::new((*this).iter(tx.as_ref().unwrap()));
-                YMapIterator(static_iter).into()
-            },
-            SharedType::Prelim(v) => unsafe {
-                let this: *const HashMap<String, JsValue> = v;
-                let static_iter: ManuallyDrop<
-                    std::collections::hash_map::Iter<'static, String, JsValue>,
-                > = ManuallyDrop::new((*this).iter());
-                PrelimMapIterator(static_iter).into()
-            },
-        })
-    }
-}
-
-#[pyclass(unsendable)]
-pub struct YMapIterator { inner: ManuallyDrop<MapIter<'static, 'static>>}
-
-impl Deref for YMapIterator {
-
-    fn deref(self) {
-        self.inner.deref();
-    }
-}
-
-impl Drop for YMapIterator {
-    fn drop(&mut self) {
-        unsafe { ManuallyDrop::drop(&mut self.inner) }
-    }
-}
-
-impl<'a> From<Option<(&'a String, Value)>> for IteratorNext {
-    fn from(entry: Option<(&'a String, Value)>) -> Self {
-        match entry {
-            None => IteratorNext::finished(),
-            Some((k, v)) => {
-                let tuple = js_sys::Array::new_with_length(2);
-                tuple.set(0, JsValue::from(k));
-                tuple.set(1, value_into_js(v));
-                IteratorNext::new(tuple.into())
-            }
-        }
-    }
-}
-
-#[pymethods]
-impl YMapIterator {
-    pub fn next(&mut self) -> IteratorNext {
-        self.inner.next().into()
-    }
-}
-
-#[pyclass]
-pub struct PrelimMapIterator(
-    ManuallyDrop<std::collections::hash_map::Iter<'static, String, JsValue>>,
-);
-
-impl Drop for PrelimMapIterator {
-    fn drop(&mut self) {
-        unsafe { ManuallyDrop::drop(&mut self.inner) }
-    }
-}
-
-#[pymethods]
-impl PrelimMapIterator {
-    pub fn next(&mut self) -> IteratorNext {
-        if let Some((key, value)) = self.inner.next() {
-            let array = js_sys::Array::new_with_length(2);
-            array.push(&JsValue::from(key));
-            array.push(value);
-            IteratorNext::new(array.into())
-        } else {
-            IteratorNext::finished()
-        }
-    }
-}
-
-/// XML element data type. It represents an XML node, which can contain key-value attributes
-/// (interpreted as strings) as well as other nested XML elements or rich text (represented by
-/// `YXmlText` type).
-///
-/// In terms of conflict resolution, `YXmlElement` uses following rules:
-///
-/// - Attribute updates use logical last-write-wins principle, meaning the past updates are
-///   automatically overridden and discarded by newer ones, while concurrent updates made by
-///   different peers are resolved into a single value using document id seniority to establish
-///   an order.
-/// - Child node insertion uses sequencing rules from other Yrs collections - elements are inserted
-///   using interleave-resistant algorithm, where order of concurrent inserts at the same index
-///   is established using peer's document id seniority.
-#[pyclass]
-pub struct YXmlElement(XmlElement);
-
-#[pymethods]
-impl YXmlElement {
-    /// Returns a tag name of this XML node.
-    #[getter]
-    pub fn name(&self) -> String {
-        self.inner.tag().to_string()
-    }
-
-    /// Returns a number of child XML nodes stored within this `YXMlElement` instance.
-    pub fn length(&self, txn: &YTransaction) -> u32 {
-        self.inner.len(txn)
-    }
-
-    /// Inserts a new instance of `YXmlElement` as a child of this XML node and returns it.
-    pub fn insert_xml_element(
-        &self,
-        txn: &mut YTransaction,
-        index: u32,
-        name: &str,
-    ) -> YXmlElement {
-        YXmlElement(self.inner.insert_elem(txn, index, name))
-    }
-
-    /// Inserts a new instance of `YXmlText` as a child of this XML node and returns it.
-    pub fn insert_xml_text(&self, txn: &mut YTransaction, index: u32) -> YXmlText {
-        YXmlText(self.inner.insert_text(txn, index))
-    }
-
-    /// Removes a range of children XML nodes from this `YXmlElement` instance,
-    /// starting at given `index`.
-
-    pub fn delete(&self, txn: &mut YTransaction, index: u32, length: u32) {
-        self.inner.remove_range(txn, index, length)
-    }
-
-    /// Appends a new instance of `YXmlElement` as the last child of this XML node and returns it.
-    pub fn push_xml_element(&self, txn: &mut YTransaction, name: &str) -> YXmlElement {
-        YXmlElement(self.inner.push_elem_back(txn, name))
-    }
-
-    /// Appends a new instance of `YXmlText` as the last child of this XML node and returns it.
-    pub fn push_xml_text(&self, txn: &mut YTransaction) -> YXmlText {
-        YXmlText(self.inner.push_text_back(txn))
-    }
-
-    /// Returns a first child of this XML node.
-    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node has not children.
-    pub fn first_child(&self, txn: &YTransaction) -> JsValue {
-        if let Some(xml) = self.inner.first_child(txn) {
-            xml_into_js(xml)
-        } else {
-            JsValue::undefined()
-        }
-    }
-
-    /// Returns a next XML sibling node of this XMl node.
-    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a last child of
-    /// parent XML node.
-    pub fn next_sibling(&self, txn: &YTransaction) -> JsValue {
-        if let Some(xml) = self.inner.next_sibling(txn) {
-            xml_into_js(xml)
-        } else {
-            JsValue::undefined()
-        }
-    }
-
-    /// Returns a previous XML sibling node of this XMl node.
-    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a first child
-    /// of parent XML node.
-    pub fn prev_sibling(&self, txn: &YTransaction) -> JsValue {
-        if let Some(xml) = self.inner.prev_sibling(txn) {
-            xml_into_js(xml)
-        } else {
-            JsValue::undefined()
-        }
-    }
-
-    /// Returns a parent `YXmlElement` node or `undefined` if current node has no parent assigned.
-    pub fn parent(&self, txn: &YTransaction) -> JsValue {
-        if let Some(xml) = self.inner.parent(txn) {
-            xml_into_js(Xml::Element(xml))
-        } else {
-            JsValue::undefined()
-        }
-    }
-
-    /// Returns a string representation of this XML node.
-    pub fn to_string(&self, txn: &YTransaction) -> String {
-        self.inner.to_string(txn)
-    }
-
-    /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
-    /// `name` already existed on that node, its value with be overridden with a provided one.
-    pub fn set_attribute(&self, txn: &mut YTransaction, name: &str, value: &str) {
-        self.inner.insert_attribute(txn, name, value)
-    }
-
-    /// Returns a value of an attribute given its `name`. If no attribute with such name existed,
-    /// `null` will be returned.
-    pub fn get_attribute(&self, txn: &YTransaction, name: &str) -> Option<String> {
-        self.inner.get_attribute(txn, name)
-    }
-
-    /// Removes an attribute from this XML node, given its `name`.
-
-    pub fn remove_attribute(&self, txn: &mut YTransaction, name: &str) {
-        self.inner.remove_attribute(txn, name);
-    }
-
-    /// Returns an iterator that enables to traverse over all attributes of this XML node in
-    /// unspecified order.
-
-    pub fn attributes(&self, txn: &YTransaction) -> JsValue {
-        to_iter(unsafe {
-            let this: *const XmlElement = &self.inner;
-            let tx: *const Transaction<'static> = txn.0.deref();
-            let static_iter: ManuallyDrop<Attributes<'static, 'static>> =
-                ManuallyDrop::new((*this).attributes(tx.as_ref().unwrap()));
-            YXmlAttributes(static_iter).into()
-        })
-    }
-
-    /// Returns an iterator that enables a deep traversal of this XML node - starting from first
-    /// child over this XML node successors using depth-first strategy.
-
-    pub fn tree_walker(&self, txn: &YTransaction) -> JsValue {
-        to_iter(unsafe {
-            let this: *const XmlElement = &self.inner;
-            let tx: *const Transaction<'static> = txn.0.deref();
-            let static_iter: ManuallyDrop<TreeWalker<'static, 'static>> =
-                ManuallyDrop::new((*this).successors(tx.as_ref().unwrap()));
-            YXmlTreeWalker(static_iter).into()
-        })
-    }
-}
-
-#[pyclass]
-pub struct YXmlAttributes(ManuallyDrop<Attributes<'static, 'static>>);
-
-impl Drop for YXmlAttributes {
-    fn drop(&mut self) {
-        unsafe { ManuallyDrop::drop(&mut self.inner) }
-    }
-}
-
-impl<'a> From<Option<(&'a str, String)>> for IteratorNext {
-    fn from(o: Option<(&'a str, String)>) -> Self {
-        match o {
-            None => IteratorNext::finished(),
-            Some((name, value)) => {
-                let tuple = js_sys::Array::new_with_length(2);
-                tuple.set(0, JsValue::from_str(name));
-                tuple.set(1, JsValue::from(&value));
-                IteratorNext::new(tuple.into())
-            }
-        }
-    }
-}
-
-#[pymethods]
-impl YXmlAttributes {
-    pub fn next(&mut self) -> IteratorNext {
-        self.inner.next().into()
-    }
-}
-
-#[pyclass]
-pub struct YXmlTreeWalker(ManuallyDrop<TreeWalker<'static, 'static>>);
-
-impl Drop for YXmlTreeWalker {
-    fn drop(&mut self) {
-        unsafe { ManuallyDrop::drop(&mut self.inner) }
-    }
-}
-
-#[pymethods]
-impl YXmlTreeWalker {
-    pub fn next(&mut self) -> IteratorNext {
-        if let Some(xml) = self.inner.next() {
-            let js_val = xml_into_js(xml);
-            IteratorNext::new(js_val)
-        } else {
-            IteratorNext::finished()
-        }
-    }
-}
-
-/// A shared data type used for collaborative text editing, that can be used in a context of
-/// `YXmlElement` nodee. It enables multiple users to add and remove chunks of text in efficient
-/// manner. This type is internally represented as a mutable double-linked list of text chunks
-/// - an optimization occurs during `YTransaction.commit`, which allows to squash multiple
-/// consecutively inserted characters together as a single chunk of text even between transaction
-/// boundaries in order to preserve more efficient memory model.
-///
-/// Just like `YXmlElement`, `YXmlText` can be marked with extra metadata in form of attributes.
-///
-/// `YXmlText` structure internally uses UTF-8 encoding and its length is described in a number of
-/// bytes rather than individual characters (a single UTF-8 code point can consist of many bytes).
-///
-/// Like all Yrs shared data types, `YXmlText` is resistant to the problem of interleaving (situation
-/// when characters inserted one after another may interleave with other peers concurrent inserts
-/// after merging all updates together). In case of Yrs conflict resolution is solved by using
-/// unique document id to determine correct and consistent ordering.
-#[pyclass]
-pub struct YXmlText { inner: XmlText}
-
-#[pymethods]
-impl YXmlText {
-    /// Returns length of an underlying string stored in this `YXmlText` instance,
-    /// understood as a number of UTF-8 encoded bytes.
-    #[getter]
-    pub fn length(&self) -> u32 {
-        self.inner.len()
-    }
-
-    /// Inserts a given `chunk` of text into this `YXmlText` instance, starting at a given `index`.
-
-    pub fn insert(&self, txn: &mut YTransaction, index: i32, chunk: &str) {
-        self.inner.insert(txn, index as u32, chunk)
-    }
-
-    /// Appends a given `chunk` of text at the end of `YXmlText` instance.
-
-    pub fn push(&self, txn: &mut YTransaction, chunk: &str) {
-        self.inner.push(txn, chunk)
-    }
-
-    /// Deletes a specified range of of characters, starting at a given `index`.
-    /// Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
-
-    pub fn delete(&self, txn: &mut YTransaction, index: u32, length: u32) {
-        self.inner.remove_range(txn, index, length)
-    }
-
-    /// Returns a next XML sibling node of this XMl node.
-    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a last child of
-    /// parent XML node.
-
-    pub fn next_sibling(&self, txn: &YTransaction) -> JsValue {
-        if let Some(xml) = self.inner.next_sibling(txn) {
-            xml_into_js(xml)
-        } else {
-            JsValue::undefined()
-        }
-    }
-
-    /// Returns a previous XML sibling node of this XMl node.
-    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a first child
-    /// of parent XML node.
-
-    pub fn prev_sibling(&self, txn: &YTransaction) -> JsValue {
-        if let Some(xml) = self.inner.prev_sibling(txn) {
-            xml_into_js(xml)
-        } else {
-            JsValue::undefined()
-        }
-    }
-
-    /// Returns a parent `YXmlElement` node or `undefined` if current node has no parent assigned.
-
-    pub fn parent(&self, txn: &YTransaction) -> JsValue {
-        if let Some(xml) = self.inner.parent(txn) {
-            xml_into_js(Xml::Element(xml))
-        } else {
-            JsValue::undefined()
-        }
-    }
-
-    /// Returns an underlying string stored in this `YXmlText` instance.
-
-    pub fn to_string(&self, txn: &YTransaction) -> String {
-        self.inner.to_string(txn)
-    }
-
-    /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
-    /// `name` already existed on that node, its value with be overridden with a provided one.
-
-    pub fn set_attribute(&self, txn: &mut YTransaction, name: &str, value: &str) {
-        self.inner.insert_attribute(txn, name, value);
-    }
-
-    /// Returns a value of an attribute given its `name`. If no attribute with such name existed,
-    /// `null` will be returned.
-
-    pub fn get_attribute(&self, txn: &YTransaction, name: &str) -> Option<String> {
-        self.inner.get_attribute(txn, name)
-    }
-
-    /// Removes an attribute from this XML node, given its `name`.
-
-    pub fn remove_attribute(&self, txn: &mut YTransaction, name: &str) {
-        self.inner.remove_attribute(txn, name);
-    }
-
-    /// Returns an iterator that enables to traverse over all attributes of this XML node in
-    /// unspecified order.
-
-    pub fn attributes(&self, txn: &YTransaction) -> YXmlAttributes {
-        unsafe {
-            let this: *const XmlText = &self.inner;
-            let tx: *const Transaction<'static> = txn.0.deref();
-            let static_iter: ManuallyDrop<Attributes<'static, 'static>> =
-                ManuallyDrop::new((*this).attributes(tx.as_ref().unwrap()));
-            YXmlAttributes(static_iter)
-        }
-    }
-}
-
-#[repr(transparent)]
-struct JsValueWrapper(JsValue);
-
-impl Prelim for JsValueWrapper {
+impl Prelim for PyAnyWrapper {
     fn into_content(self, _txn: &mut Transaction, ptr: TypePtr) -> (ItemContent, Option<Self>) {
-        let content = if let Some(any) = js_into_any(&self.inner) {
+        let content = if let Some(any) = py_into_any(&self.inner) {
             ItemContent::Any(vec![any])
-        } else if let Ok(shared) = Shared::try_from(&self.inner) {
+        } else if let Ok(shared) = Shared::extract(&self.inner) {
             if shared.is_prelim() {
                 let branch = BranchRef::new(Branch::new(ptr, shared.type_ref(), None));
                 ItemContent::Type(branch)
@@ -1420,36 +1448,36 @@ impl Prelim for JsValueWrapper {
     }
 
     fn integrate(self, txn: &mut Transaction, inner_ref: BranchRef) {
-        if let Ok(shared) = Shared::try_from(&self.inner) {
+        if let Ok(shared) = Shared::extract(&self.inner) {
             if shared.is_prelim() {
                 match shared {
                     Shared::Text(v) => {
                         let text = Text::from(inner_ref);
                         if let SharedType::Prelim(v) =
-                            v.0.replace(SharedType::Integrated(text.clone()))
+                            v.inner.replace(SharedType::Integrated(text.clone()))
                         {
                             text.push(txn, v.as_str());
                         }
                     }
-                    Shared::Array(v) => {
-                        let array = Array::from(inner_ref);
-                        if let SharedType::Prelim(items) =
-                            v.0.replace(SharedType::Integrated(array.clone()))
-                        {
-                            let len = array.len();
-                            insert_at(&array, txn, len, items);
-                        }
-                    }
-                    Shared::Map(v) => {
-                        let map = Map::from(inner_ref);
-                        if let SharedType::Prelim(entries) =
-                            v.0.replace(SharedType::Integrated(map.clone()))
-                        {
-                            for (k, v) in entries {
-                                map.insert(txn, k, JsValueWrapper(v));
-                            }
-                        }
-                    }
+                    // Shared::Array(v) => {
+                    //     let array = Array::from(inner_ref);
+                    //     if let SharedType::Prelim(items) =
+                    //         v.0.replace(SharedType::Integrated(array.clone()))
+                    //     {
+                    //         let len = array.len();
+                    //         insert_at(&array, txn, len, items);
+                    //     }
+                    // }
+                    // Shared::Map(v) => {
+                    //     let map = Map::from(inner_ref);
+                    //     if let SharedType::Prelim(entries) =
+                    //         v.0.replace(SharedType::Integrated(map.clone()))
+                    //     {
+                    //         for (k, v) in entries {
+                    //             map.insert(txn, k, PyAnyWrapper { inner: v });
+                    //         }
+                    //     }
+                    // }
                     _ => panic!("Cannot integrate this type"),
                 }
             }
@@ -1457,67 +1485,71 @@ impl Prelim for JsValueWrapper {
     }
 }
 
-fn insert_at(dst: &Array, txn: &mut Transaction, index: u32, src: Vec<JsValue>) {
-    let mut j = index;
-    let mut i = 0;
-    while i < src.len() {
-        let mut anys = Vec::default();
-        while i < src.len() {
-            let js = &src[i];
-            if let Some(any) = js_into_any(js) {
-                anys.push(any);
-                i += 1;
-            } else {
-                break;
-            }
-        }
+// fn insert_at(dst: &Array, txn: &mut Transaction, index: u32, src: Vec<PyAny>) {
+//     let mut j = index;
+//     let mut i = 0;
+//     while i < src.len() {
+//         let mut anys = Vec::default();
+//         while i < src.len() {
+//             let py = &src[i];
+//             if let Some(any) = py_into_any(py) {
+//                 anys.push(any);
+//                 i += 1;
+//             } else {
+//                 break;
+//             }
+//         }
 
-        if !anys.is_empty() {
-            let len = anys.len() as u32;
-            dst.insert_range(txn, j, anys);
-            j += len;
-        } else {
-            let js = &src[i];
-            let wrapper = JsValueWrapper(js.clone());
-            dst.insert(txn, j, wrapper);
-            i += 1;
-            j += 1;
-        }
-    }
-}
+//         if !anys.is_empty() {
+//             let len = anys.len() as u32;
+//             dst.insert_range(txn, j, anys);
+//             j += len;
+//         } else {
+//             let wrapper = PyAnyWrapper { inner: src[i] };
+//             dst.insert(txn, j, wrapper);
+//             i += 1;
+//             j += 1;
+//         }
+//     }
+// }
 
-fn js_into_any(v: &JsValue) -> Option<Any> {
-    if v.is_string() {
-        Some(Any::String(v.as_string()?))
-    } else if v.is_bigint() {
-        let i = js_sys::BigInt::from(v.clone()).as_f64()?;
+fn py_into_any(v: &PyAny) -> Option<Any> {
+    if let Ok(s) = v.downcast::<pytypes::PyString>() {
+        Some(Any::String(s.extract().unwrap()))
+    } else if let Ok(l) = v.downcast::<pytypes::PyLong>() {
+        let i: f64 = l.extract().unwrap();
         Some(Any::BigInt(i as i64))
-    } else if v.is_null() {
-        Some(Any::Null)
-    } else if v.is_undefined() {
-        Some(Any::Undefined)
-    } else if let Some(f) = v.as_f64() {
-        Some(Any::Number(f))
-    } else if let Some(b) = v.as_bool() {
-        Some(Any::Bool(b))
-    } else if js_sys::Array::is_array(v) {
-        let array = js_sys::Array::from(v);
-        let mut result = Vec::with_capacity(array.length() as usize);
-        for value in array.iter() {
-            result.push(js_into_any(&value)?);
+    }
+    // TODO: Handle Null vals
+    // else if let Ok(s) = v.downcast::<pytypes::Null>() {
+    //     Some(Any::Null)
+    // }
+    // else if v.is_undefined() {
+    //     Some(Any::Undefined)
+    // }
+    else if let Ok(f) = v.downcast::<pytypes::PyFloat>() {
+        Some(Any::Number(f.extract().unwrap()))
+    } else if let Ok(b) = v.downcast::<pytypes::PyBool>() {
+        Some(Any::Bool(b.extract().unwrap()))
+    } else if let Ok(list) = v.downcast::<pytypes::PyList>() {
+        let mut result = Vec::with_capacity(list.len());
+        for value in list.iter() {
+            result.push(py_into_any(&value)?);
         }
         Some(Any::Array(result))
-    } else if v.is_object() {
-        if let Ok(_) = Shared::try_from(v) {
+    } else if let Ok(dict) = v.downcast::<pytypes::PyDict>() {
+        if let Ok(_) = Shared::extract(v) {
             None
         } else {
-            let object = js_sys::Object::from(v.clone());
             let mut result = HashMap::new();
-            let entries = js_sys::Object::entries(&object);
-            for tuple in entries.iter() {
-                let tuple = js_sys::Array::from(&tuple);
-                let key = tuple.get(0).as_string()?;
-                let value = js_into_any(&tuple.get(1))?;
+            for (k, v) in dict.iter() {
+                // TODO: Handle non string keys
+                let key = k
+                    .downcast::<pytypes::PyString>()
+                    .unwrap()
+                    .extract()
+                    .unwrap();
+                let value = py_into_any(v)?;
                 result.insert(key, value);
             }
             Some(Any::Map(result))
@@ -1527,119 +1559,150 @@ fn js_into_any(v: &JsValue) -> Option<Any> {
     }
 }
 
-fn any_into_js(v: Any) -> JsValue {
-    match v {
-        Any::Null => JsValue::NULL,
-        Any::Undefined => JsValue::UNDEFINED,
-        Any::Bool(v) => JsValue::from_bool(v),
-        Any::Number(v) => JsValue::from(v),
-        Any::BigInt(v) => JsValue::from(v),
-        Any::String(v) => JsValue::from(&v),
-        Any::Buffer(v) => {
-            let v = Vec<u8>::from(v.as_ref());
-            v.into()
-        }
-        Any::Array(v) => {
-            let a = js_sys::Array::new();
-            for value in v {
-                a.push(&any_into_js(value));
+pub struct AnyWrapper {
+    inner: Any,
+}
+
+impl IntoPy<pyo3::PyObject> for AnyWrapper {
+    fn into_py(self, py: Python) -> pyo3::PyObject {
+        match self.inner {
+            Any::Null | Any::Undefined => py.None(),
+            Any::Bool(v) => v.into_py(py),
+            Any::Number(v) => v.into_py(py),
+            Any::BigInt(v) => v.into_py(py),
+            Any::String(v) => v.into_py(py),
+            Any::Buffer(v) => {
+                unreachable!();
+                // pytypes::PyByteArray::new(v)
+                // pytypes::PyByteArray::from(v)
+                // let v = Vec::<u8>::from(v.as_ref());
+                // v.into_py(py)
             }
-            a.into()
-        }
-        Any::Map(v) => {
-            let m = js_sys::Object::new();
-            for (k, v) in v {
-                let key = JsValue::from(&k);
-                let value = any_into_js(v);
-                js_sys::Reflect::set(&m, &key, &value).unwrap();
+            Any::Array(v) => {
+                let mut a = Vec::new();
+                for value in v {
+                    let value = AnyWrapper { inner: value };
+                    a.push(value);
+                }
+                a.into_py(py)
             }
-            m.into()
+            Any::Map(v) => {
+                let mut m = HashMap::new();
+                for (k, v) in v {
+                    let value = AnyWrapper { inner: v };
+                    m.insert(k, value);
+                }
+                m.into_py(py)
+            }
         }
     }
 }
 
-fn value_into_js(v: Value) -> JsValue {
-    match v {
-        Value::Any(v) => any_into_js(v),
-        Value::YText(v) => YText::from(v).into(),
-        Value::YArray(v) => YArray::from(v).into(),
-        Value::YMap(v) => YMap::from(v).into(),
-        Value::YXmlElement(v) => YXmlElement(v).into(),
-        Value::YXmlText(v) => YXmlText(v).into(),
+impl Deref for AnyWrapper {
+    type Target = Any;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
-fn xml_into_js(v: Xml) -> JsValue {
-    match v {
-        Xml::Element(v) => YXmlElement(v).into(),
-        Xml::Text(v) => YXmlText(v).into(),
-    }
+pub struct ValueWrapper {
+    inner: Value,
 }
 
-enum Shared<'a> {
-    Text(Ref<'a, YText>),
-    Array(Ref<'a, YArray>),
-    Map(Ref<'a, YMap>),
-    XmlElement(Ref<'a, YXmlElement>),
-    XmlText(Ref<'a, YXmlText>),
-}
-
-fn as_ref<'a, T>(js: u32) -> Ref<'a, T> {
-    unsafe {
-        let js = js as *mut wasm_bindgen::__rt::WasmRefCell<T>;
-        (*js).borrow()
-    }
-}
-
-impl<'a> TryFrom<&'a JsValue> for Shared<'a> {
-    type Error = JsValue;
-
-    fn try_from(js: &'a JsValue) -> Result<Self, Self::Error> {
-        use js_sys::{Object, Reflect};
-        let ctor_name = Object::get_prototype_of(js).constructor().name();
-        let ptr = Reflect::get(js, &JsValue::from_str("ptr"))?;
-        let ptr_u32: u32 = ptr.as_f64().ok_or(JsValue::NULL)? as u32;
-        if ctor_name == "YText" {
-            Ok(Shared::Text(as_ref(ptr_u32)))
-        } else if ctor_name == "YArray" {
-            Ok(Shared::Array(as_ref(ptr_u32)))
-        } else if ctor_name == "YMap" {
-            Ok(Shared::Map(as_ref(ptr_u32)))
-        } else if ctor_name == "YXmlElement" {
-            Ok(Shared::XmlElement(as_ref(ptr_u32)))
-        } else if ctor_name == "YXmlText" {
-            Ok(Shared::XmlText(as_ref(ptr_u32)))
-        } else {
-            Err(JsValue::NULL)
+impl IntoPy<pyo3::PyObject> for ValueWrapper {
+    fn into_py(self, py: Python) -> pyo3::PyObject {
+        match self.inner {
+            Value::Any(v) => AnyWrapper { inner: v }.into_py(py),
+            Value::YText(v) => YText::from(v).into_py(py),
+            //YText::from(v).into(),
+            Value::YArray(v) => unreachable!(),
+            // YArray::from(v).into(),
+            Value::YMap(v) => unreachable!(),
+            //YMap::from(v).into(),
+            Value::YXmlElement(v) => unreachable!(),
+            //YXmlElement(v).into(),
+            Value::YXmlText(v) => unreachable!(),
+            // YXmlText(v).into(),
         }
     }
 }
 
-impl<'a> Shared<'a> {
+// fn xml_into_js(v: Xml) -> PyAny {
+//     match v {
+//         Xml::Element(v) => YXmlElement(v).into(),
+//         Xml::Text(v) => YXmlText(v).into(),
+//     }
+// }
+
+#[derive(FromPyObject)]
+enum Shared {
+    Text(YText),
+    // Array(Ref<'a, YArray>),
+    // Map(Ref<'a, YMap>),
+    // XmlElement(Ref<'a, YXmlElement>),
+    // XmlText(Ref<'a, YXmlText>),
+}
+// TODO: pointer deref?
+// fn as_ref<'a, T>(py: u32) -> Ref<'a, T> {
+//     unsafe {
+//         let py = py as *mut wasm_bindgen::__rt::WasmRefCell<T>;
+//         (*py).borrow()
+//     }
+// }
+
+// impl<'a> TryFrom<&'a PyAny> for Shared<'a> {
+//     type Error = PyAny;
+
+//     // TODO
+//     fn try_from(py: &'a PyAny) -> Result<Self, Self::Error> {
+//         let ctor_name = Object::get_prototype_of(py).constructor().name();
+//         let ptr = Reflect::get(py, &PyAny::from_str("ptr"))?;
+//         let ptr_u32: u32 = ptr.as_f64().ok_or(PyAny::NULL)? as u32;
+//         if ctor_name == "YText" {
+//             Ok(Shared::Text(as_ref(ptr_u32)))
+//         }
+//         else if ctor_name == "YArray" {
+//             Ok(Shared::Array(as_ref(ptr_u32)))
+//         } else if ctor_name == "YMap" {
+//             Ok(Shared::Map(as_ref(ptr_u32)))
+//         } else if ctor_name == "YXmlElement" {
+//             Ok(Shared::XmlElement(as_ref(ptr_u32)))
+//         } else if ctor_name == "YXmlText" {
+//             Ok(Shared::XmlText(as_ref(ptr_u32)))
+//         }
+//         else {
+//             Err(PyAny::NULL)
+//         }
+//     }
+// }
+
+impl Shared {
     fn is_prelim(&self) -> bool {
         match self {
             Shared::Text(v) => v.prelim(),
-            Shared::Array(v) => v.prelim(),
-            Shared::Map(v) => v.prelim(),
-            Shared::XmlElement(_) | Shared::XmlText(_) => false,
+            // Shared::Array(v) => v.prelim(),
+            // Shared::Map(v) => v.prelim(),
+            // Shared::XmlElement(_) | Shared::XmlText(_) => false,
         }
     }
 
     fn type_ref(&self) -> TypeRefs {
         match self {
             Shared::Text(_) => TYPE_REFS_TEXT,
-            Shared::Array(_) => TYPE_REFS_ARRAY,
-            Shared::Map(_) => TYPE_REFS_MAP,
-            Shared::XmlElement(_) => TYPE_REFS_XML_ELEMENT,
-            Shared::XmlText(_) => TYPE_REFS_XML_TEXT,
+            // Shared::Array(_) => TYPE_REFS_ARRAY,
+            // Shared::Map(_) => TYPE_REFS_MAP,
+            // Shared::XmlElement(_) => TYPE_REFS_XML_ELEMENT,
+            // Shared::XmlText(_) => TYPE_REFS_XML_TEXT,
         }
     }
 }
 
 #[pymodule]
-fn y_py(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn y_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<YDoc>()?;
-    m.add_class::<YArray>()?;
-    // m.add_wrapped(wrap_pyfunction!(linspace))?;
+    m.add_class::<YText>()?;
+    m.add_wrapped(wrap_pyfunction!(encode_state_vector))?;
+    m.add_wrapped(wrap_pyfunction!(encode_state_as_update))?;
+    m.add_wrapped(wrap_pyfunction!(apply_update))?;
     Ok(())
 }

--- a/y-py/src/lib.rs
+++ b/y-py/src/lib.rs
@@ -1,41 +1,1645 @@
+#![feature()]
+
+use lib0::any::Any;
 use pyo3::prelude::*;
-use pyo3::types::PyAny;
+use pyo3::types::{PyAny, PyByteArray, PyDict};
 use pyo3::wrap_pyfunction;
-use pythonize::{pythonize};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
+use std::sync::{Arc, Mutex};
 use yrs;
+use yrs::block::{ItemContent, Prelim};
+use yrs::types::array::ArrayIter;
+use yrs::types::map::MapIter;
+use yrs::types::xml::{Attributes, TreeWalker};
+use yrs::types::{
+    Branch, BranchRef, TypePtr, TypeRefs, Value, TYPE_REFS_ARRAY, TYPE_REFS_MAP, TYPE_REFS_TEXT,
+    TYPE_REFS_XML_ELEMENT, TYPE_REFS_XML_TEXT,
+};
+use yrs::updates::decoder::{Decode, DecoderV1};
+use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
+use yrs::{
+    Array, DeleteSet, Doc, Map, StateVector, Text, Transaction, Update, Xml, XmlElement, XmlText,
+};
 
-#[pyfunction]
-pub fn merge_updates(updates: Vec<Vec<u8>>) -> PyResult<Py<PyAny>> {
-    // Converts a Vec<Vec<u8>>  into a   [&[u8]]
-    let updates_u8: Vec<&[u8]> = updates.iter().map(|x| &x[..]).collect();
-    let result = yrs::merge_updates(&updates_u8);
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    Ok(pythonize(py, &result)?)
+/// A ywasm document type. Documents are most important units of collaborative resources management.
+/// All shared collections live within a scope of their corresponding documents. All updates are
+/// generated on per document basis (rather than individual shared type). All operations on shared
+/// collections happen via [YTransaction], which lifetime is also bound to a document.
+///
+/// Document manages so called root types, which are top-level shared types definitions (as opposed
+/// to recursively nested types).
+///
+/// A basic workflow sample:
+///
+/// ```javascript
+/// import YDoc from 'ywasm'
+///
+/// const doc = new YDoc()
+/// const txn = doc.beginTransaction()
+/// try {
+///     const text = txn.getText('name')
+///     text.push(txn, 'hello world')
+///     const output = text.toString(txn)
+///     console.log(output)
+/// } finally {
+///     txn.free()
+/// }
+/// ```
+#[pyclass(unsendable)]
+pub struct YDoc {
+    inner: Doc,
 }
 
-#[pyfunction]
-pub fn encode_state_vector_from_update(update: Vec<u8>) -> PyResult<Py<PyAny>> {
-    let result = yrs::encode_state_vector_from_update(&update);
 
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    Ok(pythonize(py, &result)?)
+#[pymethods]
+impl YDoc {
+    /// Creates a new ywasm document. If `id` parameter was passed it will be used as this document
+    /// globally unique identifier (it's up to caller to ensure that requirement). Otherwise it will
+    /// be assigned a randomly generated number.
+    #[new]
+    pub fn new(id: Option<f64>) -> Self {
+        if let Some(id) = id {
+            YDoc {
+                inner: Doc::with_client_id(id as u64),
+            }
+        } else {
+            YDoc { inner: Doc::new() }
+        }
+    }
+
+    /// Gets globally unique identifier of this `YDoc` instance.
+    #[getter]
+    pub fn id(&self) -> f64 {
+        self.inner.client_id as f64
+    }
+
+    /// Returns a new transaction for this document. Ywasm shared data types execute their
+    /// operations in a context of a given transaction. Each document can have only one active
+    /// transaction at the time - subsequent attempts will cause exception to be thrown.
+    ///
+    /// Transactions started with `doc.beginTransaction` can be released using `transaction.free`
+    /// method.
+    ///
+    /// Example:
+    ///
+    /// ```javascript
+    /// import YDoc from 'ywasm'
+    ///
+    /// // helper function used to simplify transaction
+    /// // create/release cycle
+    /// YDoc.prototype.transact = callback => {
+    ///     const txn = this.beginTransaction()
+    ///     try {
+    ///         return callback(txn)
+    ///     } finally {
+    ///         txn.free()
+    ///     }
+    /// }
+    ///
+    /// const doc = new YDoc()
+    /// const text = doc.getText('name')
+    /// doc.transact(txn => text.insert(txn, 0, 'hello world'))
+    /// ```
+    pub fn begin_transaction(&mut self) -> YTransaction {
+        unsafe {
+            let doc: *mut Doc = &mut self.inner;
+            let static_txn: ManuallyDrop<Transaction<'static>> =
+                ManuallyDrop::new((*doc).transact());
+            YTransaction{inner: static_txn}
+        }
+    }
+
+    /// Returns a `YText` shared data type, that's accessible for subsequent accesses using given
+    /// `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YText` instance.
+    // pub fn get_text(&mut self, name: &str) -> YText {
+    //     self.begin_transaction().get_text(name)
+    // }
+
+    
+
+    /// Returns a `YMap` shared data type, that's accessible for subsequent accesses using given
+    /// `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YMap` instance.
+    // pub fn get_map(&mut self, name: &str) -> YMap {
+    //     self.begin_transaction().get_map(name)
+    // }
+
+    /// Returns a `YXmlElement` shared data type, that's accessible for subsequent accesses using
+    /// given `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YXmlElement` instance.
+    // pub fn get_xml_element(&mut self, name: &str) -> YXmlElement {
+    //     self.begin_transaction().get_xml_element(name)
+    // }
+
+    /// Returns a `YXmlText` shared data type, that's accessible for subsequent accesses using given
+    /// `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YXmlText` instance.
+    // pub fn get_xml_text(&mut self, name: &str) -> YXmlText {
+    //     self.begin_transaction().get_xml_text(name)
+    // }
+
+    /// Returns a `YArray` shared data type, that's accessible for subsequent accesses using given
+    /// `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YArray` instance.
+    pub fn get_array(&mut self, name: &str) -> YArray {
+        self.begin_transaction().get_array(name)
+    }
 }
 
+/// Encodes a state vector of a given ywasm document into its binary representation using lib0 v1
+/// encoding. State vector is a compact representation of updates performed on a given document and
+/// can be used by `encode_state_as_update` on remote peer to generate a delta update payload to
+/// synchronize changes between peers.
+///
+/// Example:
+///
+/// ```javascript
+/// import {YDoc, encodeStateVector, encodeStateAsUpdate, applyUpdate} from 'ywasm'
+///
+/// /// document on machine A
+/// const localDoc = new YDoc()
+/// const localSV = encodeStateVector(localDoc)
+///
+/// // document on machine B
+/// const remoteDoc = new YDoc()
+/// const remoteDelta = encodeStateAsUpdate(remoteDoc, localSV)
+///
+/// applyUpdate(localDoc, remoteDelta)
+/// ```
 #[pyfunction]
-pub fn diff_updates(update: Vec<u8>, state_vector: Vec<u8>) -> PyResult<Py<PyAny>> {
-    let result = yrs::diff_updates(&update, &state_vector);
-
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    Ok(pythonize(py, &result)?)
+pub fn encode_state_vector(doc: &mut YDoc) -> Vec<u8> {
+    doc.begin_transaction().state_vector_v1()
 }
 
-#[pymodule(y_py)]
+/// Encodes all updates that have happened since a given version `vector` into a compact delta
+/// representation using lib0 v1 encoding. If `vector` parameter has not been provided, generated
+/// delta payload will contain all changes of a current ywasm document, working effectivelly as its
+/// state snapshot.
+///
+/// Example:
+///
+/// ```javascript
+/// import {YDoc, encodeStateVector, encodeStateAsUpdate, applyUpdate} from 'ywasm'
+///
+/// /// document on machine A
+/// const localDoc = new YDoc()
+/// const localSV = encodeStateVector(localDoc)
+///
+/// // document on machine B
+/// const remoteDoc = new YDoc()
+/// const remoteDelta = encodeStateAsUpdate(remoteDoc, localSV)
+///
+/// applyUpdate(localDoc, remoteDelta)
+/// ```
+#[pyfunction]
+pub fn encode_state_as_update(doc: &mut YDoc, vector: Option<Vec<u8>>) -> Vec<u8> {
+    doc.begin_transaction().diff_v1(vector)
+}
+
+/// Applies delta update generated by the remote document replica to a current document. This
+/// method assumes that a payload maintains lib0 v1 encoding format.
+///
+/// Example:
+///
+/// ```javascript
+/// import {YDoc, encodeStateVector, encodeStateAsUpdate, applyUpdate} from 'ywasm'
+///
+/// /// document on machine A
+/// const localDoc = new YDoc()
+/// const localSV = encodeStateVector(localDoc)
+///
+/// // document on machine B
+/// const remoteDoc = new YDoc()
+/// const remoteDelta = encodeStateAsUpdate(remoteDoc, localSV)
+///
+/// applyUpdate(localDoc, remoteDelta)
+/// ```
+#[pyfunction]
+pub fn apply_update(doc: &mut YDoc, diff: Vec<u8>) {
+    doc.begin_transaction().apply_v1(diff);
+}
+
+/// A transaction that serves as a proxy to document block store. Ywasm shared data types execute
+/// their operations in a context of a given transaction. Each document can have only one active
+/// transaction at the time - subsequent attempts will cause exception to be thrown.
+///
+/// Transactions started with `doc.beginTransaction` can be released using `transaction.free`
+/// method.
+///
+/// Example:
+///
+/// ```javascript
+/// import YDoc from 'ywasm'
+///
+/// // helper function used to simplify transaction
+/// // create/release cycle
+/// YDoc.prototype.transact = callback => {
+///     const txn = this.beginTransaction()
+///     try {
+///         return callback(txn)
+///     } finally {
+///         txn.free()
+///     }
+/// }
+///
+/// const doc = new YDoc()
+/// const text = doc.getText('name')
+/// doc.transact(txn => text.insert(txn, 0, 'hello world'))
+/// ```
+#[pyclass(unsendable)]
+pub struct YTransaction { inner: ManuallyDrop<Transaction<'static>>}
+
+impl Deref for YTransaction {
+    type Target = Transaction<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+
+impl DerefMut for YTransaction {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.deref_mut()
+    }
+}
+
+impl Drop for YTransaction {
+    fn drop(&mut self) {
+        unsafe { ManuallyDrop::drop(&mut self.inner) }
+    }
+}
+
+#[pymethods]
+impl YTransaction {
+    /// Returns a `YText` shared data type, that's accessible for subsequent accesses using given
+    /// `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YText` instance.
+    // pub fn get_text(&mut self, name: &str) -> YText {
+    //     self.inner.get_text(name).into()
+    // }
+
+    /// Returns a `YArray` shared data type, that's accessible for subsequent accesses using given
+    /// `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YArray` instance.
+    pub fn get_array(&mut self, name: &str) -> YArray {
+        self.inner.get_array(name).into()
+    }
+
+    /// Returns a `YMap` shared data type, that's accessible for subsequent accesses using given
+    /// `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YMap` instance.
+    // pub fn get_map(&mut self, name: &str) -> YMap {
+    //     self.inner.get_map(name).into()
+    // }
+
+    /// Returns a `YXmlElement` shared data type, that's accessible for subsequent accesses using
+    /// given `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YXmlElement` instance.
+    // pub fn get_xml_element(&mut self, name: &str) -> YXmlElement {
+    //     YXmlElement(self.inner.get_xml_element(name))
+    // }
+
+    /// Returns a `YXmlText` shared data type, that's accessible for subsequent accesses using given
+    /// `name`.
+    ///
+    /// If there was no instance with this name before, it will be created and then returned.
+    ///
+    /// If there was an instance with this name, but it was of different type, it will be projected
+    /// onto `YXmlText` instance.
+    // pub fn get_xml_text(&mut self, name: &str) -> YXmlText {
+    //     YXmlText(self.inner.get_xml_text(name))
+    // }
+
+    /// Triggers a post-update series of operations without `free`ing the transaction. This includes
+    /// compaction and optimization of internal representation of updates, triggering events etc.
+    /// ywasm transactions are auto-committed when they are `free`d.
+    pub fn commit(&mut self) {
+        self.inner.commit()
+    }
+
+    /// Encodes a state vector of a given transaction document into its binary representation using
+    /// lib0 v1 encoding. State vector is a compact representation of updates performed on a given
+    /// document and can be used by `encode_state_as_update` on remote peer to generate a delta
+    /// update payload to synchronize changes between peers.
+    ///
+    /// Example:
+    ///
+    /// ```javascript
+    /// import YDoc from 'ywasm'
+    ///
+    /// /// document on machine A
+    /// const localDoc = new YDoc()
+    /// const localTxn = localDoc.beginTransaction()
+    ///
+    /// // document on machine B
+    /// const remoteDoc = new YDoc()
+    /// const remoteTxn = localDoc.beginTransaction()
+    ///
+    /// try {
+    ///     const localSV = localTxn.stateVectorV1()
+    ///     const remoteDelta = remoteTxn.diffV1(localSv)
+    ///     localTxn.applyV1(remoteDelta)
+    /// } finally {
+    ///     localTxn.free()
+    ///     remoteTxn.free()
+    /// }
+    /// ```
+    pub fn state_vector_v1(&self) -> Vec<u8> {
+        let sv = self.inner.state_vector();
+        let payload = sv.encode_v1();
+        &payload[..payload.len()]
+    }
+
+    /// Encodes all updates that have happened since a given version `vector` into a compact delta
+    /// representation using lib0 v1 encoding. If `vector` parameter has not been provided, generated
+    /// delta payload will contain all changes of a current ywasm document, working effectively as
+    /// its state snapshot.
+    ///
+    /// Example:
+    ///
+    /// ```javascript
+    /// import YDoc from 'ywasm'
+    ///
+    /// /// document on machine A
+    /// const localDoc = new YDoc()
+    /// const localTxn = localDoc.beginTransaction()
+    ///
+    /// // document on machine B
+    /// const remoteDoc = new YDoc()
+    /// const remoteTxn = localDoc.beginTransaction()
+    ///
+    /// try {
+    ///     const localSV = localTxn.stateVectorV1()
+    ///     const remoteDelta = remoteTxn.diffV1(localSv)
+    ///     localTxn.applyV1(remoteDelta)
+    /// } finally {
+    ///     localTxn.free()
+    ///     remoteTxn.free()
+    /// }
+    /// ```
+    pub fn diff_v1(&self, vector: Option<Vec<u8>>) -> Vec<u8> {
+        let mut encoder = EncoderV1::new();
+        let sv = if let Some(vector) = vector {
+            StateVector::decode_v1(vector.to_vec().as_slice())
+        } else {
+            StateVector::default()
+        };
+        self.inner.encode_diff(&sv, &mut encoder);
+        encoder.to_vec()
+    }
+
+    /// Applies delta update generated by the remote document replica to a current transaction's
+    /// document. This method assumes that a payload maintains lib0 v1 encoding format.
+    ///
+    /// Example:
+    ///
+    /// ```javascript
+    /// import YDoc from 'ywasm'
+    ///
+    /// /// document on machine A
+    /// const localDoc = new YDoc()
+    /// const localTxn = localDoc.beginTransaction()
+    ///
+    /// // document on machine B
+    /// const remoteDoc = new YDoc()
+    /// const remoteTxn = localDoc.beginTransaction()
+    ///
+    /// try {
+    ///     const localSV = localTxn.stateVectorV1()
+    ///     const remoteDelta = remoteTxn.diffV1(localSv)
+    ///     localTxn.applyV1(remoteDelta)
+    /// } finally {
+    ///     localTxn.free()
+    ///     remoteTxn.free()
+    /// }
+    /// ```
+    pub fn apply_v1(&mut self, diff: Vec<u8>) {
+        let diff: Vec<u8> = diff.to_vec();
+        let mut decoder = DecoderV1::from(diff.as_slice());
+        let update = Update::decode(&mut decoder);
+        self.inner.apply_update(update)
+    }
+}
+
+enum SharedType<T, P> {
+    Integrated(T),
+    Prelim(P),
+}
+
+impl<T, P> SharedType<T, P> {
+    #[inline(always)]
+    fn new(value: T) -> RefCell<Self> {
+        RefCell::new(SharedType::Integrated(value))
+    }
+
+    #[inline(always)]
+    fn prelim(prelim: P) -> RefCell<Self> {
+        RefCell::new(SharedType::Prelim(prelim))
+    }
+}
+
+/// A shared data type used for collaborative text editing. It enables multiple users to add and
+/// remove chunks of text in efficient manner. This type is internally represented as a mutable
+/// double-linked list of text chunks - an optimization occurs during `YTransaction.commit`, which
+/// allows to squash multiple consecutively inserted characters together as a single chunk of text
+/// even between transaction boundaries in order to preserve more efficient memory model.
+///
+/// `YText` structure internally uses UTF-8 encoding and its length is described in a number of
+/// bytes rather than individual characters (a single UTF-8 code point can consist of many bytes).
+///
+/// Like all Yrs shared data types, `YText` is resistant to the problem of interleaving (situation
+/// when characters inserted one after another may interleave with other peers concurrent inserts
+/// after merging all updates together). In case of Yrs conflict resolution is solved by using
+/// unique document id to determine correct and consistent ordering.
+#[pyclass(unsendable)]
+pub struct YText{ inner: RefCell<SharedType<Text, String>>}
+
+impl From<Text> for YText {
+    fn from(v: Text) -> Self {
+        YText{ inner: SharedType::new(v)}
+    }
+}
+
+#[pymethods]
+impl YText {
+    /// Creates a new preliminary instance of a `YText` shared data type, with its state initialized
+    /// to provided parameter.
+    ///
+    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+    /// document store and cannot be nested again: attempt to do so will result in an exception.
+    #[new]
+    pub fn new(init: Option<String>) -> Self {
+        YText { inner: SharedType::prelim(init.unwrap_or_default())}
+    }
+
+    /// Returns true if this is a preliminary instance of `YText`.
+    ///
+    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+    /// document store and cannot be nested again: attempt to do so will result in an exception.
+    #[getter]
+    pub fn prelim(&self) -> bool {
+        if let SharedType::Prelim(_) = &*self.inner.borrow() {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns length of an underlying string stored in this `YText` instance,
+    /// understood as a number of UTF-8 encoded bytes.
+    #[getter]
+    pub fn length(&self) -> u32 {
+        match &*self.inner.borrow() {
+            SharedType::Integrated(v) => v.len(),
+            SharedType::Prelim(v) => v.len() as u32,
+        }
+    }
+
+    /// Returns an underlying shared string stored in this data type.
+    // TODO: MAke this a native __str__ dunder function
+    pub fn to_string(&self, txn: &YTransaction) -> String {
+        match &*self.inner.borrow() {
+            SharedType::Integrated(v) => v.to_string(txn),
+            SharedType::Prelim(v) => v.clone(),
+        }
+    }
+
+    /// Returns an underlying shared string stored in this data type.
+    pub fn to_json(&self, txn: &YTransaction) -> JsValue {
+        match &*self.inner.borrow() {
+            SharedType::Integrated(v) => JsValue::from(&v.to_string(txn)),
+            SharedType::Prelim(v) => JsValue::from(v),
+        }
+    }
+
+    /// Inserts a given `chunk` of text into this `YText` instance, starting at a given `index`.
+    pub fn insert(&self, txn: &mut YTransaction, index: u32, chunk: &str) {
+        match &mut *self.inner.borrow_mut() {
+            SharedType::Integrated(v) => v.insert(txn, index, chunk),
+            SharedType::Prelim(v) => v.insert_str(index as usize, chunk),
+        }
+    }
+
+    /// Appends a given `chunk` of text at the end of current `YText` instance.
+    pub fn push(&self, txn: &mut YTransaction, chunk: &str) {
+        match &mut *self.inner.borrow_mut() {
+            SharedType::Integrated(v) => v.push(txn, chunk),
+            SharedType::Prelim(v) => v.push_str(chunk),
+        }
+    }
+
+    /// Deletes a specified range of of characters, starting at a given `index`.
+    /// Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
+    pub fn delete(&mut self, txn: &mut YTransaction, index: u32, length: u32) {
+        match &mut *self.inner.borrow_mut() {
+            SharedType::Integrated(v) => v.remove_range(txn, index, length),
+            SharedType::Prelim(v) => {
+                v.drain((index as usize)..(index + length) as usize);
+            }
+        }
+    }
+}
+
+/// A collection used to store data in an indexed sequence structure. This type is internally
+/// implemented as a double linked list, which may squash values inserted directly one after another
+/// into single list node upon transaction commit.
+///
+/// Reading a root-level type as an YArray means treating its sequence components as a list, where
+/// every countable element becomes an individual entity:
+///
+/// - JSON-like primitives (booleans, numbers, strings, JSON maps, arrays etc.) are counted
+///   individually.
+/// - Text chunks inserted by [Text] data structure: each character becomes an element of an
+///   array.
+/// - Embedded and binary values: they count as a single element even though they correspond of
+///   multiple bytes.
+///
+/// Like all Yrs shared data types, YArray is resistant to the problem of interleaving (situation
+/// when elements inserted one after another may interleave with other peers concurrent inserts
+/// after merging all updates together). In case of Yrs conflict resolution is solved by using
+/// unique document id to determine correct and consistent ordering.
+#[pyclass(unsendable)]
+pub struct YArray{ inner: RefCell<SharedType<Array, Vec<PyAny>>>}
+
+impl From<Array> for YArray {
+    fn from(v: Array) -> Self {
+        YArray{inner: SharedType::new(v)}
+    }
+}
+
+#[pymethods]
+impl YArray {
+    /// Creates a new preliminary instance of a `YArray` shared data type, with its state
+    /// initialized to provided parameter.
+    ///
+    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+    /// document store and cannot be nested again: attempt to do so will result in an exception.
+    #[new]
+    pub fn new(init: Option<Vec<PyAny>>) -> Self {
+        YArray {inner: SharedType::prelim(init.unwrap_or_default())}
+    }
+
+    /// Returns true if this is a preliminary instance of `YArray`.
+    ///
+    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+    /// document store and cannot be nested again: attempt to do so will result in an exception.
+    #[getter]
+    pub fn prelim(&self) -> bool {
+        if let SharedType::Prelim(_) = &*self.inner.borrow() {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns a number of elements stored within this instance of `YArray`.
+    #[getter]
+    pub fn length(&self) -> u32 {
+        match &*self.inner.borrow() {
+            SharedType::Integrated(v) => v.len(),
+            SharedType::Prelim(v) => v.len() as u32,
+        }
+    }
+
+    /// Converts an underlying contents of this `YArray` instance into their JSON representation.
+    pub fn to_json(&self, txn: &YTransaction) -> PyDict {
+        match &*self.inner.borrow() {
+            SharedType::Integrated(v) => any_into_js(v.to_json(txn)),
+            SharedType::Prelim(v) => {
+                let array = js_sys::Array::new();
+                for js in v.iter() {
+                    array.push(js);
+                }
+                array.into()
+            }
+        }
+    }
+
+    /// Inserts a given range of `items` into this `YArray` instance, starting at given `index`.
+    pub fn insert(&self, txn: &mut YTransaction, index: u32, items: Vec<JsValue>) {
+        let mut j = index;
+        match &mut *self.inner.borrow_mut() {
+            SharedType::Integrated(array) => {
+                insert_at(array, txn, index, items);
+            }
+            SharedType::Prelim(vec) => {
+                for js in items {
+                    vec.insert(j as usize, js);
+                    j += 1;
+                }
+            }
+        }
+    }
+
+    /// Appends a range of `items` at the end of this `YArray` instance.
+    pub fn push(&self, txn: &mut YTransaction, items: Vec<JsValue>) {
+        let index = self.length();
+        self.insert(txn, index, items);
+    }
+
+    /// Deletes a range of items of given `length` from current `YArray` instance,
+    /// starting from given `index`.
+    pub fn delete(&self, txn: &mut YTransaction, index: u32, length: u32) {
+        match &mut *self.inner.borrow_mut() {
+            SharedType::Integrated(v) => v.remove_range(txn, index, length),
+            SharedType::Prelim(v) => {
+                v.drain((index as usize)..(index + length) as usize);
+            }
+        }
+    }
+
+    /// Returns an element stored under given `index`.
+    pub fn get(&self, txn: &YTransaction, index: u32) -> Result<JsValue, JsValue> {
+        match &*self.inner.borrow() {
+            SharedType::Integrated(v) => {
+                if let Some(value) = v.get(txn, index) {
+                    Ok(value_into_js(value))
+                } else {
+                    Err(JsValue::from("Index outside the bounds of an YArray"))
+                }
+            }
+            SharedType::Prelim(v) => {
+                if let Some(value) = v.get(index as usize) {
+                    Ok(value.clone())
+                } else {
+                    Err(JsValue::from("Index outside the bounds of an YArray"))
+                }
+            }
+        }
+    }
+
+    /// Returns an iterator that can be used to traverse over the values stored withing this
+    /// instance of `YArray`.
+    ///
+    /// Example:
+    ///
+    /// ```javascript
+    /// import YDoc from 'ywasm'
+    ///
+    /// /// document on machine A
+    /// const doc = new YDoc()
+    /// const array = doc.getArray('name')
+    /// const txn = doc.beginTransaction()
+    /// try {
+    ///     array.push(txn, ['hello', 'world'])
+    ///     for (let item of array.values(txn)) {
+    ///         console.log(item)
+    ///     }
+    /// } finally {
+    ///     txn.free()
+    /// }
+    /// ```
+    pub fn values(&self, txn: &YTransaction) -> JsValue {
+        to_iter(match &*self.inner.borrow() {
+            SharedType::Integrated(v) => unsafe {
+                let this: *const Array = v;
+                let tx: *const Transaction<'static> = txn.0.deref();
+                let static_iter: ManuallyDrop<ArrayIter<'static, 'static>> =
+                    ManuallyDrop::new((*this).iter(tx.as_ref().unwrap()));
+                YArrayIterator(static_iter).into()
+            },
+            SharedType::Prelim(v) => unsafe {
+                let this: *const Vec<JsValue> = v;
+                let static_iter: ManuallyDrop<std::slice::Iter<'static, JsValue>> =
+                    ManuallyDrop::new((*this).iter());
+                PrelimArrayIterator(static_iter).into()
+            },
+        })
+    }
+}
+
+fn to_iter(iterator: JsValue) -> JsValue {
+    let iter = js_sys::Object::new();
+    let symbol_iter = js_sys::Symbol::iterator();
+    let cb = Closure::once_into_js(move || iterator);
+    js_sys::Reflect::set(&iter, &symbol_iter.into(), &cb).unwrap();
+    iter.into()
+}
+
+#[pyclass]
+pub struct IteratorNext {
+    value: JsValue,
+    done: bool,
+}
+
+#[pymethods]
+impl IteratorNext {
+    #[new]
+    fn new(value: JsValue) -> Self {
+        IteratorNext { done: false, value }
+    }
+
+    #[staticmethod] // TODO: Check if this is really static
+    fn finished() -> Self {
+        IteratorNext {
+            done: true,
+            value: JsValue::undefined(),
+        }
+    }
+
+    #[getter]
+    pub fn value(&self) -> JsValue {
+        self.value.clone()
+    }
+
+    #[getter]
+    pub fn done(&self) -> bool {
+        self.done
+    }
+}
+
+impl From<Option<Value>> for IteratorNext {
+    fn from(v: Option<Value>) -> Self {
+        match v {
+            None => IteratorNext::finished(),
+            Some(v) => IteratorNext::new(value_into_js(v)),
+        }
+    }
+}
+
+#[pyclass]
+pub struct YArrayIterator(ManuallyDrop<ArrayIter<'static, 'static>>);
+
+impl Drop for YArrayIterator {
+    fn drop(&mut self) {
+        unsafe { ManuallyDrop::drop(&mut self.inner) }
+    }
+}
+
+#[pymethods]
+impl YArrayIterator {
+    pub fn next(&mut self) -> IteratorNext {
+        self.inner.next().into()
+    }
+}
+
+#[pyclass]
+pub struct PrelimArrayIterator(ManuallyDrop<std::slice::Iter<'static, JsValue>>);
+
+impl Drop for PrelimArrayIterator {
+    fn drop(&mut self) {
+        unsafe { ManuallyDrop::drop(&mut self.inner) }
+    }
+}
+
+#[pymethods]
+impl PrelimArrayIterator {
+    pub fn next(&mut self) -> IteratorNext {
+        if let Some(js) = self.inner.next() {
+            IteratorNext::new(js.clone())
+        } else {
+            IteratorNext::finished()
+        }
+    }
+}
+
+/// Collection used to store key-value entries in an unordered manner. Keys are always represented
+/// as UTF-8 strings. Values can be any value type supported by Yrs: JSON-like primitives as well as
+/// shared data types.
+///
+/// In terms of conflict resolution, [Map] uses logical last-write-wins principle, meaning the past
+/// updates are automatically overridden and discarded by newer ones, while concurrent updates made
+/// by different peers are resolved into a single value using document id seniority to establish
+/// order.
+#[pyclass]
+pub struct YMap(RefCell<SharedType<Map, HashMap<String, JsValue>>>);
+
+impl From<Map> for YMap {
+    fn from(v: Map) -> Self {
+        YMap(SharedType::new(v))
+    }
+}
+
+#[pymethods]
+impl YMap {
+    /// Creates a new preliminary instance of a `YMap` shared data type, with its state
+    /// initialized to provided parameter.
+    ///
+    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+    /// document store and cannot be nested again: attempt to do so will result in an exception.
+    #[new]
+    pub fn new(init: Option<js_sys::Object>) -> Self {
+        let map = if let Some(object) = init {
+            let mut map = HashMap::new();
+            let entries = js_sys::Object::entries(&object);
+            for tuple in entries.iter() {
+                let tuple = js_sys::Array::from(&tuple);
+                let key = tuple.get(0).as_string().unwrap();
+                let value = tuple.get(1);
+                map.insert(key, value);
+            }
+            map
+        } else {
+            HashMap::new()
+        };
+        YMap(SharedType::prelim(map))
+    }
+
+    /// Returns true if this is a preliminary instance of `YMap`.
+    ///
+    /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.
+    /// Once a preliminary instance has been inserted this way, it becomes integrated into ywasm
+    /// document store and cannot be nested again: attempt to do so will result in an exception.
+    #[getter]
+    pub fn prelim(&self) -> bool {
+        if let SharedType::Prelim(_) = &*self.inner.borrow() {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns a number of entries stored within this instance of `YMap`.
+    pub fn length(&self, txn: &YTransaction) -> u32 {
+        match &*self.inner.borrow() {
+            SharedType::Integrated(v) => v.len(txn),
+            SharedType::Prelim(v) => v.len() as u32,
+        }
+    }
+
+    /// Converts contents of this `YMap` instance into a JSON representation.
+    pub fn to_json(&self, txn: &YTransaction) -> JsValue {
+        match &*self.inner.borrow() {
+            SharedType::Integrated(v) => any_into_js(v.to_json(txn)),
+            SharedType::Prelim(v) => {
+                let map = js_sys::Object::new();
+                for (k, v) in v.iter() {
+                    js_sys::Reflect::set(&map, &k.into(), v).unwrap();
+                }
+                map.into()
+            }
+        }
+    }
+
+    /// Sets a given `key`-`value` entry within this instance of `YMap`. If another entry was
+    /// already stored under given `key`, it will be overridden with new `value`.
+    pub fn set(&self, txn: &mut YTransaction, key: &str, value: JsValue) {
+        match &mut *self.inner.borrow_mut() {
+            SharedType::Integrated(v) => {
+                v.insert(txn, key.to_string(), JsValueWrapper(value));
+            }
+            SharedType::Prelim(v) => {
+                v.insert(key.to_string(), value);
+            }
+        }
+    }
+
+    /// Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.
+    pub fn delete(&mut self, txn: &mut YTransaction, key: &str) {
+        match &mut *self.inner.borrow_mut() {
+            SharedType::Integrated(v) => {
+                v.remove(txn, key);
+            }
+            SharedType::Prelim(v) => {
+                v.remove(key);
+            }
+        }
+    }
+
+    /// Returns value of an entry stored under given `key` within this instance of `YMap`,
+    /// or `undefined` if no such entry existed.
+    pub fn get(&self, txn: &mut YTransaction, key: &str) -> JsValue {
+        match &*self.inner.borrow() {
+            SharedType::Integrated(v) => {
+                if let Some(value) = v.get(txn, key) {
+                    value_into_js(value)
+                } else {
+                    JsValue::undefined()
+                }
+            }
+            SharedType::Prelim(v) => {
+                if let Some(value) = v.get(key) {
+                    value.clone()
+                } else {
+                    JsValue::undefined()
+                }
+            }
+        }
+    }
+
+    /// Returns an iterator that can be used to traverse over all entries stored within this
+    /// instance of `YMap`. Order of entry is not specified.
+    ///
+    /// Example:
+    ///
+    /// ```javascript
+    /// import YDoc from 'ywasm'
+    ///
+    /// /// document on machine A
+    /// const doc = new YDoc()
+    /// const map = doc.getMap('name')
+    /// const txn = doc.beginTransaction()
+    /// try {
+    ///     map.set(txn, 'key1', 'value1')
+    ///     map.set(txn, 'key2', true)
+    ///
+    ///     for (let [key, value] of map.entries(txn)) {
+    ///         console.log(key, value)
+    ///     }
+    /// } finally {
+    ///     txn.free()
+    /// }
+    /// ```
+    pub fn entries(&self, txn: &mut YTransaction) -> JsValue {
+        to_iter(match &*self.inner.borrow() {
+            SharedType::Integrated(v) => unsafe {
+                let this: *const Map = v;
+                let tx: *const Transaction<'static> = txn.0.deref();
+                let static_iter: ManuallyDrop<MapIter<'static, 'static>> =
+                    ManuallyDrop::new((*this).iter(tx.as_ref().unwrap()));
+                YMapIterator(static_iter).into()
+            },
+            SharedType::Prelim(v) => unsafe {
+                let this: *const HashMap<String, JsValue> = v;
+                let static_iter: ManuallyDrop<
+                    std::collections::hash_map::Iter<'static, String, JsValue>,
+                > = ManuallyDrop::new((*this).iter());
+                PrelimMapIterator(static_iter).into()
+            },
+        })
+    }
+}
+
+#[pyclass(unsendable)]
+pub struct YMapIterator { inner: ManuallyDrop<MapIter<'static, 'static>>}
+
+impl Deref for YMapIterator {
+
+    fn deref(self) {
+        self.inner.deref();
+    }
+}
+
+impl Drop for YMapIterator {
+    fn drop(&mut self) {
+        unsafe { ManuallyDrop::drop(&mut self.inner) }
+    }
+}
+
+impl<'a> From<Option<(&'a String, Value)>> for IteratorNext {
+    fn from(entry: Option<(&'a String, Value)>) -> Self {
+        match entry {
+            None => IteratorNext::finished(),
+            Some((k, v)) => {
+                let tuple = js_sys::Array::new_with_length(2);
+                tuple.set(0, JsValue::from(k));
+                tuple.set(1, value_into_js(v));
+                IteratorNext::new(tuple.into())
+            }
+        }
+    }
+}
+
+#[pymethods]
+impl YMapIterator {
+    pub fn next(&mut self) -> IteratorNext {
+        self.inner.next().into()
+    }
+}
+
+#[pyclass]
+pub struct PrelimMapIterator(
+    ManuallyDrop<std::collections::hash_map::Iter<'static, String, JsValue>>,
+);
+
+impl Drop for PrelimMapIterator {
+    fn drop(&mut self) {
+        unsafe { ManuallyDrop::drop(&mut self.inner) }
+    }
+}
+
+#[pymethods]
+impl PrelimMapIterator {
+    pub fn next(&mut self) -> IteratorNext {
+        if let Some((key, value)) = self.inner.next() {
+            let array = js_sys::Array::new_with_length(2);
+            array.push(&JsValue::from(key));
+            array.push(value);
+            IteratorNext::new(array.into())
+        } else {
+            IteratorNext::finished()
+        }
+    }
+}
+
+/// XML element data type. It represents an XML node, which can contain key-value attributes
+/// (interpreted as strings) as well as other nested XML elements or rich text (represented by
+/// `YXmlText` type).
+///
+/// In terms of conflict resolution, `YXmlElement` uses following rules:
+///
+/// - Attribute updates use logical last-write-wins principle, meaning the past updates are
+///   automatically overridden and discarded by newer ones, while concurrent updates made by
+///   different peers are resolved into a single value using document id seniority to establish
+///   an order.
+/// - Child node insertion uses sequencing rules from other Yrs collections - elements are inserted
+///   using interleave-resistant algorithm, where order of concurrent inserts at the same index
+///   is established using peer's document id seniority.
+#[pyclass]
+pub struct YXmlElement(XmlElement);
+
+#[pymethods]
+impl YXmlElement {
+    /// Returns a tag name of this XML node.
+    #[getter]
+    pub fn name(&self) -> String {
+        self.inner.tag().to_string()
+    }
+
+    /// Returns a number of child XML nodes stored within this `YXMlElement` instance.
+    pub fn length(&self, txn: &YTransaction) -> u32 {
+        self.inner.len(txn)
+    }
+
+    /// Inserts a new instance of `YXmlElement` as a child of this XML node and returns it.
+    pub fn insert_xml_element(
+        &self,
+        txn: &mut YTransaction,
+        index: u32,
+        name: &str,
+    ) -> YXmlElement {
+        YXmlElement(self.inner.insert_elem(txn, index, name))
+    }
+
+    /// Inserts a new instance of `YXmlText` as a child of this XML node and returns it.
+    pub fn insert_xml_text(&self, txn: &mut YTransaction, index: u32) -> YXmlText {
+        YXmlText(self.inner.insert_text(txn, index))
+    }
+
+    /// Removes a range of children XML nodes from this `YXmlElement` instance,
+    /// starting at given `index`.
+
+    pub fn delete(&self, txn: &mut YTransaction, index: u32, length: u32) {
+        self.inner.remove_range(txn, index, length)
+    }
+
+    /// Appends a new instance of `YXmlElement` as the last child of this XML node and returns it.
+    pub fn push_xml_element(&self, txn: &mut YTransaction, name: &str) -> YXmlElement {
+        YXmlElement(self.inner.push_elem_back(txn, name))
+    }
+
+    /// Appends a new instance of `YXmlText` as the last child of this XML node and returns it.
+    pub fn push_xml_text(&self, txn: &mut YTransaction) -> YXmlText {
+        YXmlText(self.inner.push_text_back(txn))
+    }
+
+    /// Returns a first child of this XML node.
+    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node has not children.
+    pub fn first_child(&self, txn: &YTransaction) -> JsValue {
+        if let Some(xml) = self.inner.first_child(txn) {
+            xml_into_js(xml)
+        } else {
+            JsValue::undefined()
+        }
+    }
+
+    /// Returns a next XML sibling node of this XMl node.
+    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a last child of
+    /// parent XML node.
+    pub fn next_sibling(&self, txn: &YTransaction) -> JsValue {
+        if let Some(xml) = self.inner.next_sibling(txn) {
+            xml_into_js(xml)
+        } else {
+            JsValue::undefined()
+        }
+    }
+
+    /// Returns a previous XML sibling node of this XMl node.
+    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a first child
+    /// of parent XML node.
+    pub fn prev_sibling(&self, txn: &YTransaction) -> JsValue {
+        if let Some(xml) = self.inner.prev_sibling(txn) {
+            xml_into_js(xml)
+        } else {
+            JsValue::undefined()
+        }
+    }
+
+    /// Returns a parent `YXmlElement` node or `undefined` if current node has no parent assigned.
+    pub fn parent(&self, txn: &YTransaction) -> JsValue {
+        if let Some(xml) = self.inner.parent(txn) {
+            xml_into_js(Xml::Element(xml))
+        } else {
+            JsValue::undefined()
+        }
+    }
+
+    /// Returns a string representation of this XML node.
+    pub fn to_string(&self, txn: &YTransaction) -> String {
+        self.inner.to_string(txn)
+    }
+
+    /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
+    /// `name` already existed on that node, its value with be overridden with a provided one.
+    pub fn set_attribute(&self, txn: &mut YTransaction, name: &str, value: &str) {
+        self.inner.insert_attribute(txn, name, value)
+    }
+
+    /// Returns a value of an attribute given its `name`. If no attribute with such name existed,
+    /// `null` will be returned.
+    pub fn get_attribute(&self, txn: &YTransaction, name: &str) -> Option<String> {
+        self.inner.get_attribute(txn, name)
+    }
+
+    /// Removes an attribute from this XML node, given its `name`.
+
+    pub fn remove_attribute(&self, txn: &mut YTransaction, name: &str) {
+        self.inner.remove_attribute(txn, name);
+    }
+
+    /// Returns an iterator that enables to traverse over all attributes of this XML node in
+    /// unspecified order.
+
+    pub fn attributes(&self, txn: &YTransaction) -> JsValue {
+        to_iter(unsafe {
+            let this: *const XmlElement = &self.inner;
+            let tx: *const Transaction<'static> = txn.0.deref();
+            let static_iter: ManuallyDrop<Attributes<'static, 'static>> =
+                ManuallyDrop::new((*this).attributes(tx.as_ref().unwrap()));
+            YXmlAttributes(static_iter).into()
+        })
+    }
+
+    /// Returns an iterator that enables a deep traversal of this XML node - starting from first
+    /// child over this XML node successors using depth-first strategy.
+
+    pub fn tree_walker(&self, txn: &YTransaction) -> JsValue {
+        to_iter(unsafe {
+            let this: *const XmlElement = &self.inner;
+            let tx: *const Transaction<'static> = txn.0.deref();
+            let static_iter: ManuallyDrop<TreeWalker<'static, 'static>> =
+                ManuallyDrop::new((*this).successors(tx.as_ref().unwrap()));
+            YXmlTreeWalker(static_iter).into()
+        })
+    }
+}
+
+#[pyclass]
+pub struct YXmlAttributes(ManuallyDrop<Attributes<'static, 'static>>);
+
+impl Drop for YXmlAttributes {
+    fn drop(&mut self) {
+        unsafe { ManuallyDrop::drop(&mut self.inner) }
+    }
+}
+
+impl<'a> From<Option<(&'a str, String)>> for IteratorNext {
+    fn from(o: Option<(&'a str, String)>) -> Self {
+        match o {
+            None => IteratorNext::finished(),
+            Some((name, value)) => {
+                let tuple = js_sys::Array::new_with_length(2);
+                tuple.set(0, JsValue::from_str(name));
+                tuple.set(1, JsValue::from(&value));
+                IteratorNext::new(tuple.into())
+            }
+        }
+    }
+}
+
+#[pymethods]
+impl YXmlAttributes {
+    pub fn next(&mut self) -> IteratorNext {
+        self.inner.next().into()
+    }
+}
+
+#[pyclass]
+pub struct YXmlTreeWalker(ManuallyDrop<TreeWalker<'static, 'static>>);
+
+impl Drop for YXmlTreeWalker {
+    fn drop(&mut self) {
+        unsafe { ManuallyDrop::drop(&mut self.inner) }
+    }
+}
+
+#[pymethods]
+impl YXmlTreeWalker {
+    pub fn next(&mut self) -> IteratorNext {
+        if let Some(xml) = self.inner.next() {
+            let js_val = xml_into_js(xml);
+            IteratorNext::new(js_val)
+        } else {
+            IteratorNext::finished()
+        }
+    }
+}
+
+/// A shared data type used for collaborative text editing, that can be used in a context of
+/// `YXmlElement` nodee. It enables multiple users to add and remove chunks of text in efficient
+/// manner. This type is internally represented as a mutable double-linked list of text chunks
+/// - an optimization occurs during `YTransaction.commit`, which allows to squash multiple
+/// consecutively inserted characters together as a single chunk of text even between transaction
+/// boundaries in order to preserve more efficient memory model.
+///
+/// Just like `YXmlElement`, `YXmlText` can be marked with extra metadata in form of attributes.
+///
+/// `YXmlText` structure internally uses UTF-8 encoding and its length is described in a number of
+/// bytes rather than individual characters (a single UTF-8 code point can consist of many bytes).
+///
+/// Like all Yrs shared data types, `YXmlText` is resistant to the problem of interleaving (situation
+/// when characters inserted one after another may interleave with other peers concurrent inserts
+/// after merging all updates together). In case of Yrs conflict resolution is solved by using
+/// unique document id to determine correct and consistent ordering.
+#[pyclass]
+pub struct YXmlText { inner: XmlText}
+
+#[pymethods]
+impl YXmlText {
+    /// Returns length of an underlying string stored in this `YXmlText` instance,
+    /// understood as a number of UTF-8 encoded bytes.
+    #[getter]
+    pub fn length(&self) -> u32 {
+        self.inner.len()
+    }
+
+    /// Inserts a given `chunk` of text into this `YXmlText` instance, starting at a given `index`.
+
+    pub fn insert(&self, txn: &mut YTransaction, index: i32, chunk: &str) {
+        self.inner.insert(txn, index as u32, chunk)
+    }
+
+    /// Appends a given `chunk` of text at the end of `YXmlText` instance.
+
+    pub fn push(&self, txn: &mut YTransaction, chunk: &str) {
+        self.inner.push(txn, chunk)
+    }
+
+    /// Deletes a specified range of of characters, starting at a given `index`.
+    /// Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
+
+    pub fn delete(&self, txn: &mut YTransaction, index: u32, length: u32) {
+        self.inner.remove_range(txn, index, length)
+    }
+
+    /// Returns a next XML sibling node of this XMl node.
+    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a last child of
+    /// parent XML node.
+
+    pub fn next_sibling(&self, txn: &YTransaction) -> JsValue {
+        if let Some(xml) = self.inner.next_sibling(txn) {
+            xml_into_js(xml)
+        } else {
+            JsValue::undefined()
+        }
+    }
+
+    /// Returns a previous XML sibling node of this XMl node.
+    /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a first child
+    /// of parent XML node.
+
+    pub fn prev_sibling(&self, txn: &YTransaction) -> JsValue {
+        if let Some(xml) = self.inner.prev_sibling(txn) {
+            xml_into_js(xml)
+        } else {
+            JsValue::undefined()
+        }
+    }
+
+    /// Returns a parent `YXmlElement` node or `undefined` if current node has no parent assigned.
+
+    pub fn parent(&self, txn: &YTransaction) -> JsValue {
+        if let Some(xml) = self.inner.parent(txn) {
+            xml_into_js(Xml::Element(xml))
+        } else {
+            JsValue::undefined()
+        }
+    }
+
+    /// Returns an underlying string stored in this `YXmlText` instance.
+
+    pub fn to_string(&self, txn: &YTransaction) -> String {
+        self.inner.to_string(txn)
+    }
+
+    /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
+    /// `name` already existed on that node, its value with be overridden with a provided one.
+
+    pub fn set_attribute(&self, txn: &mut YTransaction, name: &str, value: &str) {
+        self.inner.insert_attribute(txn, name, value);
+    }
+
+    /// Returns a value of an attribute given its `name`. If no attribute with such name existed,
+    /// `null` will be returned.
+
+    pub fn get_attribute(&self, txn: &YTransaction, name: &str) -> Option<String> {
+        self.inner.get_attribute(txn, name)
+    }
+
+    /// Removes an attribute from this XML node, given its `name`.
+
+    pub fn remove_attribute(&self, txn: &mut YTransaction, name: &str) {
+        self.inner.remove_attribute(txn, name);
+    }
+
+    /// Returns an iterator that enables to traverse over all attributes of this XML node in
+    /// unspecified order.
+
+    pub fn attributes(&self, txn: &YTransaction) -> YXmlAttributes {
+        unsafe {
+            let this: *const XmlText = &self.inner;
+            let tx: *const Transaction<'static> = txn.0.deref();
+            let static_iter: ManuallyDrop<Attributes<'static, 'static>> =
+                ManuallyDrop::new((*this).attributes(tx.as_ref().unwrap()));
+            YXmlAttributes(static_iter)
+        }
+    }
+}
+
+#[repr(transparent)]
+struct JsValueWrapper(JsValue);
+
+impl Prelim for JsValueWrapper {
+    fn into_content(self, _txn: &mut Transaction, ptr: TypePtr) -> (ItemContent, Option<Self>) {
+        let content = if let Some(any) = js_into_any(&self.inner) {
+            ItemContent::Any(vec![any])
+        } else if let Ok(shared) = Shared::try_from(&self.inner) {
+            if shared.is_prelim() {
+                let branch = BranchRef::new(Branch::new(ptr, shared.type_ref(), None));
+                ItemContent::Type(branch)
+            } else {
+                panic!("Cannot integrate this type")
+            }
+        } else {
+            panic!("Cannot integrate this type")
+        };
+
+        let this = if let ItemContent::Type(_) = &content {
+            Some(self)
+        } else {
+            None
+        };
+
+        (content, this)
+    }
+
+    fn integrate(self, txn: &mut Transaction, inner_ref: BranchRef) {
+        if let Ok(shared) = Shared::try_from(&self.inner) {
+            if shared.is_prelim() {
+                match shared {
+                    Shared::Text(v) => {
+                        let text = Text::from(inner_ref);
+                        if let SharedType::Prelim(v) =
+                            v.0.replace(SharedType::Integrated(text.clone()))
+                        {
+                            text.push(txn, v.as_str());
+                        }
+                    }
+                    Shared::Array(v) => {
+                        let array = Array::from(inner_ref);
+                        if let SharedType::Prelim(items) =
+                            v.0.replace(SharedType::Integrated(array.clone()))
+                        {
+                            let len = array.len();
+                            insert_at(&array, txn, len, items);
+                        }
+                    }
+                    Shared::Map(v) => {
+                        let map = Map::from(inner_ref);
+                        if let SharedType::Prelim(entries) =
+                            v.0.replace(SharedType::Integrated(map.clone()))
+                        {
+                            for (k, v) in entries {
+                                map.insert(txn, k, JsValueWrapper(v));
+                            }
+                        }
+                    }
+                    _ => panic!("Cannot integrate this type"),
+                }
+            }
+        }
+    }
+}
+
+fn insert_at(dst: &Array, txn: &mut Transaction, index: u32, src: Vec<JsValue>) {
+    let mut j = index;
+    let mut i = 0;
+    while i < src.len() {
+        let mut anys = Vec::default();
+        while i < src.len() {
+            let js = &src[i];
+            if let Some(any) = js_into_any(js) {
+                anys.push(any);
+                i += 1;
+            } else {
+                break;
+            }
+        }
+
+        if !anys.is_empty() {
+            let len = anys.len() as u32;
+            dst.insert_range(txn, j, anys);
+            j += len;
+        } else {
+            let js = &src[i];
+            let wrapper = JsValueWrapper(js.clone());
+            dst.insert(txn, j, wrapper);
+            i += 1;
+            j += 1;
+        }
+    }
+}
+
+fn js_into_any(v: &JsValue) -> Option<Any> {
+    if v.is_string() {
+        Some(Any::String(v.as_string()?))
+    } else if v.is_bigint() {
+        let i = js_sys::BigInt::from(v.clone()).as_f64()?;
+        Some(Any::BigInt(i as i64))
+    } else if v.is_null() {
+        Some(Any::Null)
+    } else if v.is_undefined() {
+        Some(Any::Undefined)
+    } else if let Some(f) = v.as_f64() {
+        Some(Any::Number(f))
+    } else if let Some(b) = v.as_bool() {
+        Some(Any::Bool(b))
+    } else if js_sys::Array::is_array(v) {
+        let array = js_sys::Array::from(v);
+        let mut result = Vec::with_capacity(array.length() as usize);
+        for value in array.iter() {
+            result.push(js_into_any(&value)?);
+        }
+        Some(Any::Array(result))
+    } else if v.is_object() {
+        if let Ok(_) = Shared::try_from(v) {
+            None
+        } else {
+            let object = js_sys::Object::from(v.clone());
+            let mut result = HashMap::new();
+            let entries = js_sys::Object::entries(&object);
+            for tuple in entries.iter() {
+                let tuple = js_sys::Array::from(&tuple);
+                let key = tuple.get(0).as_string()?;
+                let value = js_into_any(&tuple.get(1))?;
+                result.insert(key, value);
+            }
+            Some(Any::Map(result))
+        }
+    } else {
+        None
+    }
+}
+
+fn any_into_js(v: Any) -> JsValue {
+    match v {
+        Any::Null => JsValue::NULL,
+        Any::Undefined => JsValue::UNDEFINED,
+        Any::Bool(v) => JsValue::from_bool(v),
+        Any::Number(v) => JsValue::from(v),
+        Any::BigInt(v) => JsValue::from(v),
+        Any::String(v) => JsValue::from(&v),
+        Any::Buffer(v) => {
+            let v = Vec<u8>::from(v.as_ref());
+            v.into()
+        }
+        Any::Array(v) => {
+            let a = js_sys::Array::new();
+            for value in v {
+                a.push(&any_into_js(value));
+            }
+            a.into()
+        }
+        Any::Map(v) => {
+            let m = js_sys::Object::new();
+            for (k, v) in v {
+                let key = JsValue::from(&k);
+                let value = any_into_js(v);
+                js_sys::Reflect::set(&m, &key, &value).unwrap();
+            }
+            m.into()
+        }
+    }
+}
+
+fn value_into_js(v: Value) -> JsValue {
+    match v {
+        Value::Any(v) => any_into_js(v),
+        Value::YText(v) => YText::from(v).into(),
+        Value::YArray(v) => YArray::from(v).into(),
+        Value::YMap(v) => YMap::from(v).into(),
+        Value::YXmlElement(v) => YXmlElement(v).into(),
+        Value::YXmlText(v) => YXmlText(v).into(),
+    }
+}
+
+fn xml_into_js(v: Xml) -> JsValue {
+    match v {
+        Xml::Element(v) => YXmlElement(v).into(),
+        Xml::Text(v) => YXmlText(v).into(),
+    }
+}
+
+enum Shared<'a> {
+    Text(Ref<'a, YText>),
+    Array(Ref<'a, YArray>),
+    Map(Ref<'a, YMap>),
+    XmlElement(Ref<'a, YXmlElement>),
+    XmlText(Ref<'a, YXmlText>),
+}
+
+fn as_ref<'a, T>(js: u32) -> Ref<'a, T> {
+    unsafe {
+        let js = js as *mut wasm_bindgen::__rt::WasmRefCell<T>;
+        (*js).borrow()
+    }
+}
+
+impl<'a> TryFrom<&'a JsValue> for Shared<'a> {
+    type Error = JsValue;
+
+    fn try_from(js: &'a JsValue) -> Result<Self, Self::Error> {
+        use js_sys::{Object, Reflect};
+        let ctor_name = Object::get_prototype_of(js).constructor().name();
+        let ptr = Reflect::get(js, &JsValue::from_str("ptr"))?;
+        let ptr_u32: u32 = ptr.as_f64().ok_or(JsValue::NULL)? as u32;
+        if ctor_name == "YText" {
+            Ok(Shared::Text(as_ref(ptr_u32)))
+        } else if ctor_name == "YArray" {
+            Ok(Shared::Array(as_ref(ptr_u32)))
+        } else if ctor_name == "YMap" {
+            Ok(Shared::Map(as_ref(ptr_u32)))
+        } else if ctor_name == "YXmlElement" {
+            Ok(Shared::XmlElement(as_ref(ptr_u32)))
+        } else if ctor_name == "YXmlText" {
+            Ok(Shared::XmlText(as_ref(ptr_u32)))
+        } else {
+            Err(JsValue::NULL)
+        }
+    }
+}
+
+impl<'a> Shared<'a> {
+    fn is_prelim(&self) -> bool {
+        match self {
+            Shared::Text(v) => v.prelim(),
+            Shared::Array(v) => v.prelim(),
+            Shared::Map(v) => v.prelim(),
+            Shared::XmlElement(_) | Shared::XmlText(_) => false,
+        }
+    }
+
+    fn type_ref(&self) -> TypeRefs {
+        match self {
+            Shared::Text(_) => TYPE_REFS_TEXT,
+            Shared::Array(_) => TYPE_REFS_ARRAY,
+            Shared::Map(_) => TYPE_REFS_MAP,
+            Shared::XmlElement(_) => TYPE_REFS_XML_ELEMENT,
+            Shared::XmlText(_) => TYPE_REFS_XML_TEXT,
+        }
+    }
+}
+
+#[pymodule]
 fn y_py(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(merge_updates, m)?)?;
-    m.add_function(wrap_pyfunction!(encode_state_vector_from_update, m)?)?;
-    m.add_function(wrap_pyfunction!(diff_updates, m)?)?;
+    m.add_class::<YDoc>()?;
+    m.add_class::<YArray>()?;
+    // m.add_wrapped(wrap_pyfunction!(linspace))?;
     Ok(())
 }

--- a/y-py/tests/test_helper.py
+++ b/y-py/tests/test_helper.py
@@ -5,7 +5,6 @@ def transact(self,callback):
         return callback(txn)
 
 
-Y.YDoc.transact = transact
 
 def exchange_updates(docs):
     for d1 in docs:

--- a/y-py/tests/test_helper.py
+++ b/y-py/tests/test_helper.py
@@ -1,12 +1,8 @@
 import y_py as Y
 
 def transact(self,callback):
-    txn = self.beginTransaction()
-    try:
+    with self.begin_transaction() as txn:
         return callback(txn)
-    finally:
-        txn.commit()
-        txn.free()
 
 
 Y.YDoc.transact = transact
@@ -15,6 +11,6 @@ def exchange_updates(docs):
     for d1 in docs:
         for d2 in docs:
             if d1 != d2:
-                state_vector = Y.encodeStateVector(d1)
-                diff = Y.encodeStateAsUpdate(d2, state_vector)
-                Y.applyUpdate(d1, diff)
+                state_vector = Y.encode_state_vector(d1)
+                diff = Y.encode_state_as_update(d2, state_vector)
+                Y.apply_update(d1, diff)

--- a/y-py/tests/test_helper.py
+++ b/y-py/tests/test_helper.py
@@ -1,0 +1,20 @@
+import y_py as Y
+
+def transact(self,callback):
+    txn = self.beginTransaction()
+    try:
+        return callback(txn)
+    finally:
+        txn.commit()
+        txn.free()
+
+
+Y.YDoc.transact = transact
+
+def exchange_updates(docs):
+    for d1 in docs:
+        for d2 in docs:
+            if d1 != d2:
+                state_vector = Y.encodeStateVector(d1)
+                diff = Y.encodeStateAsUpdate(d2, state_vector)
+                Y.applyUpdate(d1, diff)

--- a/y-py/tests/test_y_array.py
+++ b/y-py/tests/test_y_array.py
@@ -108,3 +108,19 @@ def test_iterator():
         for v in x.values(txn):
             assert v == i
             i+=1
+
+def test_borrow_mut_edge_case():
+    """
+    Tests for incorrect overlap in successive mutable borrows of YTransaction and YArray.
+    """
+    doc = YDoc()
+    arr = doc.get_array('test')
+    with doc.begin_transaction() as txn:
+        arr.insert(txn, 0, [1,2,3])
+    
+    # Ensure multiple transactions can be called in a row with the same variable name `txn`
+    with doc.begin_transaction() as txn:
+        # Ensure that multiple mutable borrow functions can be called in a tight loop
+        for i in range(2000):
+            arr.insert(txn, [1,2,3])
+            arr.delete(txn, 0, 3)

--- a/y-py/tests/test_y_array.py
+++ b/y-py/tests/test_y_array.py
@@ -1,0 +1,112 @@
+from test_helper import exchange_updates
+import pytest
+
+import y_py as Y
+
+def testInserts():
+    d1 = Y.YDoc(1)
+    assert d1.id == 1
+    x = d1.get_array('test');
+
+    d1.transact(lambda txn : x.insert(txn, 0, [1, 2.5, 'hello', ['world'], True]))
+    d1.transact(lambda txn : x.push(txn, [{"key":'value'}]))
+
+    expected = [1, 2.5, 'hello', ['world'], True, {"key":'value'}]
+
+    value = d1.transact(lambda txn : x.to_json(txn))
+    assert value == expected # TODO: Make this an arr cmp
+
+    d2 = Y.YDoc(2)
+    x = d2.get_array('test');
+
+    exchange_updates([d1, d2])
+
+    value = d2.transact(lambda txn : x.to_json(txn))
+    assert value ==expected
+
+def testInsertsNested():
+    d1 = Y.YDoc()
+    x = d1.get_array('test');
+
+    nested = Y.YArray();
+    d1.transact(lambda txn : nested.push(txn, ['world']))
+    d1.transact(lambda txn : x.insert(txn, 0, [1, 2, nested, 3, 4]))
+    d1.transact(lambda txn : nested.insert(txn, 0, ['hello']))
+
+    expected = [1, 2, ['hello', 'world'], 3, 4]
+
+    value = d1.transact(lambda txn : x.to_json(txn))
+    assert value ==expected
+
+    d2 = Y.YDoc()
+    x = d2.get_array('test');
+
+    exchange_updates([d1, d2])
+
+    value = d2.transact(lambda txn : x.to_json(txn))
+    assert value ==expected
+
+def test_delete ():
+    d1 = Y.YDoc(1)
+    assert d1.id == 1
+    x = d1.get_array('test')
+
+    d1.transact(lambda txn : x.insert(txn, 0, [1, 2, ['hello', 'world'], True]))
+    d1.transact(lambda txn : x.delete(txn, 1, 2))
+
+    expected = [1, True]
+
+    value = d1.transact(lambda txn : x.to_json(txn))
+    assert value ==expected
+
+    d2 = Y.YDoc(2)
+    x = d2.get_array('test')
+
+    exchange_updates([d1, d2])
+
+    value = d2.transact(lambda txn : x.to_json(txn))
+    assert value ==expected
+
+def test_get():
+    d1 = Y.YDoc()
+    x = d1.get_array('test')
+
+    d1.transact(lambda txn : x.insert(txn, 0, [1, 2, True]))
+    d1.transact(lambda txn : x.insert(txn, 1, ['hello', 'world']));
+
+    zeroed = d1.transact(lambda txn : x.get(txn, 0))
+    first = d1.transact(lambda txn : x.get(txn, 1))
+    second = d1.transact(lambda txn : x.get(txn, 2))
+    third = d1.transact(lambda txn : x.get(txn, 3))
+    fourth = d1.transact(lambda txn : x.get(txn, 4))
+
+    assert zeroed == 1
+
+    assert first == 'hello'
+
+    assert second == 'world'
+
+    assert third == 2
+
+    assert fourth == True
+
+    # t.fails(() => {
+    #     // should fail because it's outside of the bounds
+    #     d1.transact(lambda txn : x.get(txn, 5))
+    # })
+
+def test_iterator():
+    d1 = Y.YDoc()
+    x = d1.get_array('test')
+
+    d1.transact(lambda txn : x.insert(txn, 0, [1, 2, 3]))
+    assert x.length == 3
+
+    txn = d1.begin_transaction()
+    try:
+        i = 1
+        for v in x.values(txn):
+            assert v == i
+            i+=1
+    finally:
+        txn.free()

--- a/y-py/tests/test_y_array.py
+++ b/y-py/tests/test_y_array.py
@@ -26,9 +26,9 @@ def testInserts():
 
 def testInsertsNested():
     d1 = Y.YDoc()
-    x = d1.get_array('test');
+    x = d1.get_array('test')
 
-    nested = Y.YArray();
+    nested = Y.YArray()
     d1.transact(lambda txn : nested.push(txn, ['world']))
     d1.transact(lambda txn : x.insert(txn, 0, [1, 2, nested, 3, 4]))
     d1.transact(lambda txn : nested.insert(txn, 0, ['hello']))
@@ -90,10 +90,8 @@ def test_get():
 
     assert fourth == True
 
-    # t.fails(() => {
-    #     // should fail because it's outside of the bounds
-    #     d1.transact(lambda txn : x.get(txn, 5))
-    # })
+    with pytest.raises(IndexError):
+        x = d1.transact(lambda txn : x.get(txn, 20))
 
 def test_iterator():
     d1 = Y.YDoc()
@@ -102,11 +100,8 @@ def test_iterator():
     d1.transact(lambda txn : x.insert(txn, 0, [1, 2, 3]))
     assert x.length == 3
 
-    txn = d1.begin_transaction()
-    try:
+    with d1.begin_transaction() as txn:
         i = 1
         for v in x.values(txn):
             assert v == i
             i+=1
-    finally:
-        txn.free()

--- a/y-py/tests/test_y_array.py
+++ b/y-py/tests/test_y_array.py
@@ -5,7 +5,6 @@ from y_py import YDoc, YArray
 
 def test_inserts():
     d1 = YDoc(1)
-    assert d1.id == 1
     x = d1.get_array('test');
 
     with d1.begin_transaction() as txn:

--- a/y-py/tests/test_y_array.py
+++ b/y-py/tests/test_y_array.py
@@ -1,22 +1,25 @@
 from test_helper import exchange_updates
 import pytest
 
-import y_py as Y
+from y_py import YDoc, YArray
 
-def testInserts():
-    d1 = Y.YDoc(1)
+def test_inserts():
+    d1 = YDoc(1)
     assert d1.id == 1
     x = d1.get_array('test');
 
-    d1.transact(lambda txn : x.insert(txn, 0, [1, 2.5, 'hello', ['world'], True]))
-    d1.transact(lambda txn : x.push(txn, [{"key":'value'}]))
+    with d1.begin_transaction() as txn:
+        x.insert(txn, 0, [1, 2.5, 'hello', ['world'], True])
+    
+    with d1.begin_transaction() as txn:
+        x.push(txn, [{"key":'value'}])
 
     expected = [1, 2.5, 'hello', ['world'], True, {"key":'value'}]
 
     value = d1.transact(lambda txn : x.to_json(txn))
     assert value == expected # TODO: Make this an arr cmp
 
-    d2 = Y.YDoc(2)
+    d2 = YDoc(2)
     x = d2.get_array('test');
 
     exchange_updates([d1, d2])
@@ -24,11 +27,11 @@ def testInserts():
     value = d2.transact(lambda txn : x.to_json(txn))
     assert value ==expected
 
-def testInsertsNested():
-    d1 = Y.YDoc()
+def test_inserts_nested():
+    d1 = YDoc()
     x = d1.get_array('test')
 
-    nested = Y.YArray()
+    nested = YArray()
     d1.transact(lambda txn : nested.push(txn, ['world']))
     d1.transact(lambda txn : x.insert(txn, 0, [1, 2, nested, 3, 4]))
     d1.transact(lambda txn : nested.insert(txn, 0, ['hello']))
@@ -38,7 +41,7 @@ def testInsertsNested():
     value = d1.transact(lambda txn : x.to_json(txn))
     assert value ==expected
 
-    d2 = Y.YDoc()
+    d2 = YDoc()
     x = d2.get_array('test');
 
     exchange_updates([d1, d2])
@@ -46,8 +49,8 @@ def testInsertsNested():
     value = d2.transact(lambda txn : x.to_json(txn))
     assert value ==expected
 
-def test_delete ():
-    d1 = Y.YDoc(1)
+def test_delete():
+    d1 = YDoc(1)
     assert d1.id == 1
     x = d1.get_array('test')
 
@@ -59,7 +62,7 @@ def test_delete ():
     value = d1.transact(lambda txn : x.to_json(txn))
     assert value ==expected
 
-    d2 = Y.YDoc(2)
+    d2 = YDoc(2)
     x = d2.get_array('test')
 
     exchange_updates([d1, d2])
@@ -68,7 +71,7 @@ def test_delete ():
     assert value ==expected
 
 def test_get():
-    d1 = Y.YDoc()
+    d1 = YDoc()
     x = d1.get_array('test')
 
     d1.transact(lambda txn : x.insert(txn, 0, [1, 2, True]))
@@ -94,7 +97,7 @@ def test_get():
         x = d1.transact(lambda txn : x.get(txn, 20))
 
 def test_iterator():
-    d1 = Y.YDoc()
+    d1 = YDoc()
     x = d1.get_array('test')
 
     d1.transact(lambda txn : x.insert(txn, 0, [1, 2, 3]))

--- a/y-py/tests/test_y_doc.py
+++ b/y-py/tests/test_y_doc.py
@@ -1,0 +1,27 @@
+from y_py import YDoc
+import pytest
+
+
+def test_constructor_options():
+    # Ensure that valid versions can be called without error
+    YDoc()
+    with_id = YDoc(1)
+    assert with_id.id == 1
+    YDoc(1, "utf-8", True)
+    YDoc(client_id=2, offset_kind="utf-8", skip_gc=True)
+    YDoc(client_id=3)
+    YDoc(4, skip_gc=True)
+
+    # Handle encoding string variation
+    YDoc(offset_kind="utf8")
+    YDoc(offset_kind="utf-8")
+    YDoc(offset_kind="UTF-8")
+    YDoc(offset_kind="UTF32")
+
+    # Ensure that incorrect encodings throw error
+    with pytest.raises(ValueError):
+        YDoc(offset_kind="UTF-0xDEADBEEF")
+    with pytest.raises(ValueError):
+        YDoc(offset_kind="😬")
+
+    

--- a/y-py/tests/test_y_map.py
+++ b/y-py/tests/test_y_map.py
@@ -1,0 +1,80 @@
+from test_helper import exchange_updates
+import y_py as Y
+
+def test_set():
+    d1 = Y.YDoc()
+    x = d1.get_map('test')
+
+    value = d1.transact(lambda txn : x.get(txn, 'key'))
+    assert value == None
+
+    d1.transact(lambda txn : x.set(txn, 'key', 'value1'))
+    value = d1.transact(lambda txn : x.get(txn, 'key'))
+    assert value == 'value1'
+
+    d1.transact(lambda txn : x.set(txn, 'key', 'value2'))
+    value = d1.transact(lambda txn : x.get(txn, 'key'))
+    assert value == "value2"
+
+def test_set_nested():
+    d1 = Y.YDoc()
+    x = d1.get_map('test')
+    nested = Y.YMap({ "a": 'A' })
+
+    # check out to_json(), setting a nested map in set(), adding to an integrated value
+
+    d1.transact(lambda txn : x.set(txn, 'key', nested))
+    d1.transact(lambda txn : nested.set(txn, 'b', 'B'))
+
+    json = d1.transact(lambda txn : x.to_json(txn))
+    # TODO: Make this a deep diff
+    assert json == {
+        "key": {
+            "a": 'A',
+            "b": 'B'
+        }
+    }
+
+
+def test_delete():
+    d1 = Y.YDoc()
+    x = d1.get_map('test')
+
+    d1.transact(lambda txn : x.set(txn, 'key', 'value1'))
+    len = d1.transact(lambda txn : x.length(txn))
+    value = d1.transact(lambda txn : x.get(txn, 'key'))
+    assert len == 1
+    assert value == "value1"
+    # TODO: Get length with __len__()
+    d1.transact(lambda txn : x.delete(txn, 'key'))
+    len = d1.transact(lambda txn : x.length(txn))
+    value = d1.transact(lambda txn : x.get(txn, 'key'))
+    assert len == 0
+    assert value == None
+
+    d1.transact(lambda txn : x.set(txn, 'key', 'value2'))
+    len = d1.transact(lambda txn : x.length(txn))
+    value = d1.transact(lambda txn : x.get(txn, 'key'))
+    assert len == 1
+    assert value == "value2"
+
+
+def test_iterator():
+    d1 = Y.YDoc()
+    x = d1.get_map('test')
+
+    def test(txn):
+        x.set(txn, 'a', 1)
+        x.set(txn, 'b', 2)
+        x.set(txn, 'c', 3)
+        expected = {
+            'a': 1,
+            'b': 2,
+            'c': 3
+        }
+        for (key, val) in x.entries(txn):
+            v = expected[key]
+            assert val == v
+            del expected[key]
+    d1.transact(test)
+    

--- a/y-py/tests/test_y_text.py
+++ b/y-py/tests/test_y_text.py
@@ -8,16 +8,10 @@ def test_inserts():
     d1 = Y.YDoc()
     x = d1.get_text('test')
 
-    with d1.begin_transaction() as txn:
-        x.push(txn, "hello!")
-    
-    with d1.begin_transaction() as txn:
-        x.insert(txn, 5, " world")
-
+    d1.transact(lambda txn : x.push(txn, "hello "))
+    d1.transact(lambda txn : x.push(txn, "world!"))
     expected = "hello world!"
-
-    with d1.begin_transaction() as txn:
-        value = x.to_string(txn)
+    value = d1.transact(lambda txn : x.to_string(txn))
     assert value == expected
 
     d2 = Y.YDoc(2)

--- a/y-py/tests/test_y_text.py
+++ b/y-py/tests/test_y_text.py
@@ -1,0 +1,54 @@
+import pytest
+from test_helper import exchange_updates
+
+import y_py as Y
+
+
+def test_inserts():
+    d1 = Y.YDoc()
+    x = d1.get_text('test')
+
+    with d1.begin_transaction() as txn:
+        x.push(txn, "hello!")
+    
+    with d1.begin_transaction() as txn:
+        x.insert(txn, 5, " world")
+
+    expected = "hello world!"
+
+    with d1.begin_transaction() as txn:
+        value = x.to_string(txn)
+    assert value == expected
+
+    d2 = Y.YDoc(2)
+    x = d2.get_text('test')
+
+    exchange_updates([d1, d2])
+
+    value = d2.transact(lambda txn : x.to_string(txn))
+    assert value == expected
+
+def test_deletes():
+    d1 = Y.YDoc()
+    x = d1.get_text('test')
+
+    d1.transact(lambda txn : x.push(txn, "hello world!"))
+
+    assert x.length == 12
+    d1.transact(lambda txn : x.delete(txn, 5, 6))
+    assert x.length == 6
+    d1.transact(lambda txn : x.insert(txn, 5, " Yrs"))
+    assert x.length == 10
+
+    expected = "hello Yrs!"
+
+    value = d1.transact(lambda txn : x.to_string(txn))
+    assert value == expected
+
+    d2 = Y.YDoc(2)
+    x = d2.get_text('test')
+
+    exchange_updates([d1, d2])
+
+    value = d2.transact(lambda txn : x.to_string(txn))
+    assert value == expected


### PR DESCRIPTION
Adds Y.rs bindings for Python:
- Current API supports `YDoc`, `YTransaction`, `YText`, `YArray`, and `YMap` with more to come.
- Major functions are documented with adapted examples from `ywasm`
- Tests are available for `YText`, `YArray`, and `YMap` in Python using `pytest`

Thanks to the maintainers working on the `ywasm` project! I based Y-Py on your JavaScript bindings and it made the process far easier to have a solid codebase from the start.